### PR TITLE
docs(ci): extend PR template with before/after table

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,7 +1,11 @@
 ## Description
 
 <!-- Please provide a meaningful description of what this change will do, or is for. Bonus points for including links to
-related issues, other PRs, or technical references.
+related issues, other PRs, or technical references and some before/after screenshots if the change affects the UI.
+
+| Before | After |
+| :---: | :---: |
+| 🖼️ | 🖼️ |
 
 Note that by _not_ including a description, you are asking reviewers to do extra work to understand the context of this
 change, which may lead to your PR taking much longer to review, or result in it not being reviewed at all. -->


### PR DESCRIPTION
Used to test pipeline, should be removed and reopened by the PR owner
