### PR TITLE
fix(ci): use github token instead of pat in image cleanup workflow

### DIFF
--- a/.github/workflows/image-cleanup.yml
+++ b/.github/workflows/image-cleanup.yml
@@ -46,7 +46,7 @@ jobs:
           cut-off: 1s
           timestamp-to-use: created_at
           account: openclarity
-          token: ${{ secrets.PAT }}
+          token: ${{ secrets.GITHUB_TOKEN }}
           image-tags: "${{ format( 'pr{0}-*', github.event.pull_request.number) }}"
           dry-run: false
 
@@ -62,7 +62,7 @@ jobs:
           cut-off: 7days
           timestamp-to-use: created_at
           account: openclarity
-          token: ${{ secrets.PAT }}
+          token: ${{ secrets.GITHUB_TOKEN }}
           tag-selection: both
           dry-run: false
 
@@ -78,6 +78,6 @@ jobs:
           cut-off: ${{ inputs.cut-off }}
           timestamp-to-use: created_at
           account: openclarity
-          token: ${{ secrets.PAT }}
+          token: ${{ secrets.GITHUB_TOKEN }}
           tag-selection: both
           dry-run: ${{ inputs.dry-run }}


### PR DESCRIPTION
## Description

Fix image cleanup workflow failing with `error: invalid value '' for '--token <TOKEN>': The `token` value is not valid. Must be $GITHUB_TOKEN, a classic personal access token (prefixed by 'ghp') or oauth token (prefixed by 'gho').` 

https://github.com/openclarity/openclarity/actions/workflows/image-cleanup.yml

## Type of Change

- [x] Bug Fix
- [ ] New Feature
- [ ] Breaking Change
- [ ] Refactor
- [ ] Documentation
- [ ] Other (please describe)

## Checklist

- [x] I have read the [contributing guidelines](https://github.com/openclarity/openclarity/blob/main/CONTRIBUTING.md)
- [ ] Existing issues have been referenced (where applicable)
- [x] I have verified this change is not present in other open pull requests
- [ ] Functionality is documented
- [x] All code style checks pass
- [ ] New code contribution is covered by automated tests
- [x] All new and existing tests pass
