### PR TITLE
fix(api): empty arch failure when vm discovered

### DIFF
--- a/api/types/asset.go
+++ b/api/types/asset.go
@@ -28,6 +28,8 @@ func (a *VMInfoArchitecture) UnmarshalText(text []byte) error {
 		arch = Amd64
 	case "arm64", "aarch64":
 		arch = Arm64
+	case "":
+		arch = Unknown
 	default:
 		return fmt.Errorf("failed to unmarshal text into VMInfoArchitecture: %s", text)
 	}
@@ -44,7 +46,7 @@ func (a *VMInfoArchitecture) MarshalText() (string, error) {
 	case Arm64:
 		return "arm64", nil
 	case Unknown:
-		return "", fmt.Errorf("unknown VMInfoArchitecture: %v", *a)
+		return "", nil
 	default:
 		return "", fmt.Errorf("failed to marshal VMInfoArchitecture into text: %v", *a)
 	}

--- a/provider/aws/discoverer/discoverer.go
+++ b/provider/aws/discoverer/discoverer.go
@@ -142,14 +142,7 @@ func (d *Discoverer) GetInstances(ctx context.Context, filters []ec2types.Filter
 func getVMInfoFromInstance(i types.Instance) (apitypes.AssetType, error) {
 	assetType := apitypes.AssetType{}
 
-	var vmArchitecture apitypes.VMInfoArchitecture
-	err := vmArchitecture.UnmarshalText([]byte(i.Architecture))
-	if err != nil {
-		return assetType, fmt.Errorf("failed to unmarshal architecture: %w", err)
-	}
-
-	err = assetType.FromVMInfo(apitypes.VMInfo{
-		Architecture:     &vmArchitecture,
+	err := assetType.FromVMInfo(apitypes.VMInfo{
 		Image:            i.Image,
 		InstanceID:       i.ID,
 		InstanceProvider: to.Ptr(apitypes.AWS),


### PR DESCRIPTION
## Description

Currently when the orchestrator finds a VM, it fails to create a new `VMInfo` because the architecture field is empty. So, we need to provide the option of `Unknown` architecture when parsing it.

Cheers to @akijakya for finding this issue!

## Type of Change

- [x] Bug Fix
- [ ] New Feature
- [ ] Breaking Change
- [ ] Refactor
- [ ] Documentation
- [ ] Other (please describe)

## Checklist

- [x] I have read the [contributing guidelines](https://github.com/openclarity/openclarity/blob/main/CONTRIBUTING.md)
- [ ] Existing issues have been referenced (where applicable)
- [x] I have verified this change is not present in other open pull requests
- [ ] Functionality is documented
- [x] All code style checks pass
- [ ] New code contribution is covered by automated tests
- [x] All new and existing tests pass
