### PR TITLE
feat(cli): migrate KubeClarity command

### DIFF
--- a/cli/cmd/asset/asset_create.go
+++ b/cli/cmd/asset/asset_create.go
@@ -30,11 +30,10 @@ import (
 	cliutils "github.com/openclarity/openclarity/scanner/utils"
 )
 
-// AssetCreateCmd represents the standalone command.
 var AssetCreateCmd = &cobra.Command{
 	Use:   "asset-create",
 	Short: "Create asset",
-	Long:  `It creates asset. It's useful in the CI/CD mode without VMClarity orchestration`,
+	Long:  `It creates asset. It's useful in the CI/CD mode without OpenClarity orchestration`,
 	Run: func(cmd *cobra.Command, args []string) {
 		logutil.Logger.Infof("Creating asset...")
 		filename, err := cmd.Flags().GetString("file")
@@ -43,7 +42,7 @@ var AssetCreateCmd = &cobra.Command{
 		}
 		server, err := cmd.Flags().GetString("server")
 		if err != nil {
-			logutil.Logger.Fatalf("Unable to get VMClarity server address: %v", err)
+			logutil.Logger.Fatalf("Unable to get OpenClarity server address: %v", err)
 		}
 		assetType, err := getAssetFromJSONFile(filename)
 		if err != nil {
@@ -76,7 +75,7 @@ var AssetCreateCmd = &cobra.Command{
 
 func init() {
 	AssetCreateCmd.Flags().String("file", "", "asset json filename")
-	AssetCreateCmd.Flags().String("server", "", "VMClarity server to create asset to, for example: http://localhost:9999/api")
+	AssetCreateCmd.Flags().String("server", "", "OpenClarity server to create asset to, for example: http://localhost:9999/api")
 	AssetCreateCmd.Flags().Bool("update-if-exists", false, "the asset will be updated the asset if it exists")
 	AssetCreateCmd.Flags().String("jsonpath", "", "print selected value of asset")
 	if err := AssetCreateCmd.MarkFlagRequired("file"); err != nil {
@@ -118,7 +117,7 @@ func getAssetFromJSONFile(filename string) (*apitypes.AssetType, error) {
 func createAsset(ctx context.Context, assetType *apitypes.AssetType, server string, updateIfExists bool) (*apitypes.Asset, error) {
 	client, err := apiclient.New(server)
 	if err != nil {
-		return nil, fmt.Errorf("failed to create VMClarity API client: %w", err)
+		return nil, fmt.Errorf("failed to create OpenClarity API client: %w", err)
 	}
 
 	creationTime := time.Now()

--- a/cli/cmd/asset/asset_scan_create.go
+++ b/cli/cmd/asset/asset_scan_create.go
@@ -28,11 +28,10 @@ import (
 	cliutils "github.com/openclarity/openclarity/scanner/utils"
 )
 
-// AssetScanCreateCmd represents the standalone command.
 var AssetScanCreateCmd = &cobra.Command{
 	Use:   "asset-scan-create",
 	Short: "Create asset scan",
-	Long:  `It creates asset scan. It's useful in the CI/CD mode without VMClarity orchestration`,
+	Long:  `It creates asset scan. It's useful in the CI/CD mode without OpenClarity orchestration`,
 	Run: func(cmd *cobra.Command, args []string) {
 		logutil.Logger.Infof("asset-scan-create called")
 		assetID, err := cmd.Flags().GetString("asset-id")
@@ -41,7 +40,7 @@ var AssetScanCreateCmd = &cobra.Command{
 		}
 		server, err := cmd.Flags().GetString("server")
 		if err != nil {
-			logutil.Logger.Fatalf("Unable to get VMClarity server address: %v", err)
+			logutil.Logger.Fatalf("Unable to get OpenClarity server address: %v", err)
 		}
 		jsonPath, err := cmd.Flags().GetString("jsonpath")
 		if err != nil {
@@ -60,7 +59,7 @@ var AssetScanCreateCmd = &cobra.Command{
 }
 
 func init() {
-	AssetScanCreateCmd.Flags().String("server", "", "VMClarity server to create asset to, for example: http://localhost:9999/api")
+	AssetScanCreateCmd.Flags().String("server", "", "OpenClarity server to create asset to, for example: http://localhost:9999/api")
 	AssetScanCreateCmd.Flags().String("asset-id", "", "Asset ID for asset scan")
 	AssetScanCreateCmd.Flags().String("jsonpath", "", "print selected value of asset scan")
 	if err := AssetScanCreateCmd.MarkFlagRequired("server"); err != nil {
@@ -74,7 +73,7 @@ func init() {
 func createAssetScan(ctx context.Context, server, assetID string) (*apitypes.AssetScan, error) {
 	client, err := apiclient.New(server)
 	if err != nil {
-		return nil, fmt.Errorf("failed to create VMClarity API client: %w", err)
+		return nil, fmt.Errorf("failed to create OpenClarity API client: %w", err)
 	}
 
 	asset, err := client.GetAsset(ctx, assetID, apitypes.GetAssetsAssetIDParams{})

--- a/cli/cmd/convert/convert.go
+++ b/cli/cmd/convert/convert.go
@@ -1,0 +1,100 @@
+// Copyright © 2024 Cisco Systems, Inc. and its affiliates.
+// All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package convert
+
+import (
+	"fmt"
+	"os"
+
+	"github.com/spf13/cobra"
+
+	"github.com/openclarity/openclarity/cli/cmd/logutil"
+	"github.com/openclarity/openclarity/cli/presenter"
+	"github.com/openclarity/openclarity/scanner/utils/converter"
+)
+
+var ConvertCmd = &cobra.Command{
+	Use:    "convert",
+	Short:  "Convert SBOM",
+	Long:   `Currently, only supports converting SBOM from cyclondx format to syft-json format`,
+	Hidden: true,
+	Run: func(cmd *cobra.Command, args []string) {
+		logutil.Logger.Infof("Converting SBOM...")
+
+		outputFormat, err := cmd.Flags().GetString("output-format")
+		if err != nil {
+			logutil.Logger.Fatalf("Unable to get output format: %v", err)
+		}
+
+		inputSBOMFile, err := cmd.Flags().GetString("input-sboms")
+		if err != nil {
+			logutil.Logger.Fatalf("Unable to get input sbom: %v", err)
+		}
+
+		var outputPath string
+		outputPath, err = cmd.Flags().GetString("output-path")
+		if err != nil {
+			outputPath, err = os.Getwd()
+			if err != nil {
+				outputPath = "."
+			}
+		}
+
+		outputSBOMFile, err := cmd.Flags().GetString("output-sbom")
+		if err != nil {
+			logutil.Logger.Fatalf("Unable to get output sbom: %v", err)
+		}
+
+		outputSbomFormat, err := converter.StringToSbomFormat(outputFormat)
+		if err != nil {
+			logutil.Logger.Fatalf("Unsupported SBOM conversion: %v", err)
+		}
+
+		bomBytes, err := convertSBOMFile(inputSBOMFile, outputSbomFormat)
+		if err != nil {
+			logutil.Logger.Fatalf("Failed to convert SBOM: %v", err)
+		}
+
+		writer := presenter.FileWriter{Path: outputPath}
+		err = writer.Write(bomBytes, outputSBOMFile)
+		if err != nil {
+			logutil.Logger.Fatalf("Failed to write SBOM: %v", err)
+		}
+	},
+}
+
+// nolint: gochecknoinits
+func init() {
+	ConvertCmd.Flags().StringP("input-format", "", "cyclonedx", "Deprecated and ignored")
+	ConvertCmd.Flags().StringP("input-sboms", "i", "", "Define input filename")
+	ConvertCmd.Flags().StringP("output-path", "op", "", "Define output path")
+	ConvertCmd.Flags().StringP("output-format", "", "json", "Define output format")
+	ConvertCmd.Flags().StringP("output-sbom", "o", "", "Define output filename")
+}
+
+func convertSBOMFile(inputSBOMFile string, outputFormat converter.SbomFormat) ([]byte, error) {
+	cdxBom, err := converter.GetCycloneDXSBOMFromFile(inputSBOMFile)
+	if err != nil {
+		return nil, fmt.Errorf("failed to get CycloneDX SBOM from file: %v", err)
+	}
+
+	bomBytes, err := converter.CycloneDxToBytes(cdxBom, outputFormat)
+	if err != nil {
+		return nil, fmt.Errorf("failed to convert CycloneDX to %v format: %v", outputFormat, err)
+	}
+
+	return bomBytes, nil
+}

--- a/cli/cmd/convert/convert.go
+++ b/cli/cmd/convert/convert.go
@@ -79,8 +79,8 @@ var ConvertCmd = &cobra.Command{
 // nolint: gochecknoinits
 func init() {
 	ConvertCmd.Flags().StringP("input-format", "", "cyclonedx", "Deprecated and ignored")
-	ConvertCmd.Flags().StringP("input-sboms", "i", "", "Define input filename")
-	ConvertCmd.Flags().StringP("output-path", "op", "", "Define output path")
+	ConvertCmd.Flags().StringP("input-sbom", "i", "", "Define input filename")
+	ConvertCmd.Flags().StringP("output-path", "p", "", "Define output path")
 	ConvertCmd.Flags().StringP("output-format", "", "json", "Define output format")
 	ConvertCmd.Flags().StringP("output-sbom", "o", "", "Define output filename")
 }
@@ -88,12 +88,12 @@ func init() {
 func convertSBOMFile(inputSBOMFile string, outputFormat converter.SbomFormat) ([]byte, error) {
 	cdxBom, err := converter.GetCycloneDXSBOMFromFile(inputSBOMFile)
 	if err != nil {
-		return nil, fmt.Errorf("failed to get CycloneDX SBOM from file: %v", err)
+		return nil, fmt.Errorf("failed to get CycloneDX SBOM from file: %w", err)
 	}
 
 	bomBytes, err := converter.CycloneDxToBytes(cdxBom, outputFormat)
 	if err != nil {
-		return nil, fmt.Errorf("failed to convert CycloneDX to %v format: %v", outputFormat, err)
+		return nil, fmt.Errorf("failed to convert CycloneDX to %v format: %w", outputFormat, err)
 	}
 
 	return bomBytes, nil

--- a/cli/cmd/root/root.go
+++ b/cli/cmd/root/root.go
@@ -25,6 +25,7 @@ import (
 	"github.com/spf13/cobra"
 
 	"github.com/openclarity/openclarity/cli/cmd/asset"
+	"github.com/openclarity/openclarity/cli/cmd/convert"
 	"github.com/openclarity/openclarity/cli/cmd/logutil"
 	"github.com/openclarity/openclarity/cli/cmd/scan"
 	"github.com/openclarity/openclarity/core/log"
@@ -33,9 +34,9 @@ import (
 
 // RootCmd represents the base command when called without any subcommands.
 var rootCmd = &cobra.Command{
-	Use:          "vmclarity",
-	Short:        "VMClarity",
-	Long:         `VMClarity`,
+	Use:          "openclarity",
+	Short:        "OpenClarity",
+	Long:         `OpenClarity`,
 	Version:      version.String(),
 	SilenceUsage: true,
 }
@@ -61,9 +62,10 @@ func init() {
 	rootCmd.AddCommand(scan.ScanCmd)
 	rootCmd.AddCommand(asset.AssetCreateCmd)
 	rootCmd.AddCommand(asset.AssetScanCreateCmd)
+	rootCmd.AddCommand(convert.ConvertCmd)
 }
 
 func initLogger() {
 	log.InitLogger(logrus.InfoLevel.String(), os.Stderr)
-	logutil.Logger = logrus.WithField("app", "vmclarity")
+	logutil.Logger = logrus.WithField("app", "openclarity")
 }

--- a/cli/cmd/scan/scan.go
+++ b/cli/cmd/scan/scan.go
@@ -42,7 +42,6 @@ const (
 	DefaultMountTimeout    = 10 * time.Minute
 )
 
-// ScanCmd represents the scan command.
 var ScanCmd = &cobra.Command{
 	Use:   "scan",
 	Short: "Scan",
@@ -60,7 +59,7 @@ var ScanCmd = &cobra.Command{
 		}
 		server, err := cmd.Flags().GetString("server")
 		if err != nil {
-			logutil.Logger.Fatalf("Unable to get VMClarity server address: %v", err)
+			logutil.Logger.Fatalf("Unable to get OpenClarity server address: %v", err)
 		}
 		output, err := cmd.Flags().GetString("output")
 		if err != nil {
@@ -140,12 +139,9 @@ var ScanCmd = &cobra.Command{
 
 // nolint: gochecknoinits
 func init() {
-	// Here you will define your flags and configuration settings.
-	// Cobra supports persistent flags, which, if defined here,
-	// will be global for your application.
-	ScanCmd.Flags().String("config", "", "config file (default is $HOME/.vmclarity.yaml)")
+	ScanCmd.Flags().String("config", "", "config file (default is $HOME/.openclarity.yaml)")
 	ScanCmd.Flags().String("output", "", "set output directory path. Stdout is used if not set.")
-	ScanCmd.Flags().String("server", "", "VMClarity server to export asset scans to, for example: http://localhost:9999/api")
+	ScanCmd.Flags().String("server", "", "OpenClarity server to export asset scans to, for example: http://localhost:9999/api")
 	ScanCmd.Flags().String("asset-scan-id", "", "the AssetScan ID to monitor and report results to")
 	ScanCmd.Flags().Bool("mount-attached-volume", false, "discover for an attached volume and mount it before the scan")
 
@@ -208,17 +204,17 @@ func newCli(config *scanner.Config, server, assetScanID, output string) (*cli.CL
 
 		client, err = apiclient.New(server)
 		if err != nil {
-			return nil, fmt.Errorf("failed to create VMClarity API client: %w", err)
+			return nil, fmt.Errorf("failed to create OpenClarity API client: %w", err)
 		}
 
-		manager, err = state.NewVMClarityState(client, assetScanID)
+		manager, err = state.NewOpenClarityState(client, assetScanID)
 		if err != nil {
-			return nil, fmt.Errorf("failed to create VMClarity state manager: %w", err)
+			return nil, fmt.Errorf("failed to create OpenClarity state manager: %w", err)
 		}
 
-		p, err = presenter.NewVMClarityPresenter(client, assetScanID)
+		p, err = presenter.NewOpenClarityPresenter(client, assetScanID)
 		if err != nil {
-			return nil, fmt.Errorf("failed to create VMClarity presenter: %w", err)
+			return nil, fmt.Errorf("failed to create OpenClarity presenter: %w", err)
 		}
 		presenters = append(presenters, p)
 	} else {

--- a/cli/presenter/openclarity.go
+++ b/cli/presenter/openclarity.go
@@ -38,41 +38,52 @@ import (
 
 type AssetScanID = apitypes.AssetScanID
 
-type VMClarityPresenter struct {
+type OpenClarityPresenter struct {
 	client *apiclient.Client
 
 	assetScanID apitypes.AssetScanID
 }
 
-func (v *VMClarityPresenter) ExportFamilyResult(ctx context.Context, res families.FamilyResult) error {
+func NewOpenClarityPresenter(client *apiclient.Client, id AssetScanID) (*OpenClarityPresenter, error) {
+	if client == nil {
+		return nil, errors.New("API client must not be nil")
+	}
+
+	return &OpenClarityPresenter{
+		client:      client,
+		assetScanID: id,
+	}, nil
+}
+
+func (o *OpenClarityPresenter) ExportFamilyResult(ctx context.Context, res families.FamilyResult) error {
 	var err error
 
 	switch res.FamilyType {
 	case families.SBOM:
-		err = v.ExportSbomResult(ctx, res)
+		err = o.ExportSbomResult(ctx, res)
 	case families.Vulnerabilities:
-		err = v.ExportVulResult(ctx, res)
+		err = o.ExportVulResult(ctx, res)
 	case families.Secrets:
-		err = v.ExportSecretsResult(ctx, res)
+		err = o.ExportSecretsResult(ctx, res)
 	case families.Exploits:
-		err = v.ExportExploitsResult(ctx, res)
+		err = o.ExportExploitsResult(ctx, res)
 	case families.Misconfiguration:
-		err = v.ExportMisconfigurationResult(ctx, res)
+		err = o.ExportMisconfigurationResult(ctx, res)
 	case families.Rootkits:
-		err = v.ExportRootkitResult(ctx, res)
+		err = o.ExportRootkitResult(ctx, res)
 	case families.Malware:
-		err = v.ExportMalwareResult(ctx, res)
+		err = o.ExportMalwareResult(ctx, res)
 	case families.InfoFinder:
-		err = v.ExportInfoFinderResult(ctx, res)
+		err = o.ExportInfoFinderResult(ctx, res)
 	case families.Plugins:
-		err = v.ExportPluginsResult(ctx, res)
+		err = o.ExportPluginsResult(ctx, res)
 	}
 
 	return err
 }
 
-func (v *VMClarityPresenter) ExportSbomResult(ctx context.Context, res families.FamilyResult) error {
-	assetScan, err := v.client.GetAssetScan(ctx, v.assetScanID, apitypes.GetAssetScansAssetScanIDParams{})
+func (o *OpenClarityPresenter) ExportSbomResult(ctx context.Context, res families.FamilyResult) error {
+	assetScan, err := o.client.GetAssetScan(ctx, o.assetScanID, apitypes.GetAssetScansAssetScanIDParams{})
 	if err != nil {
 		return fmt.Errorf("failed to get asset scan: %w", err)
 	}
@@ -113,7 +124,7 @@ func (v *VMClarityPresenter) ExportSbomResult(ctx context.Context, res families.
 		}
 	}
 
-	err = v.client.PatchAssetScan(ctx, assetScan, v.assetScanID)
+	err = o.client.PatchAssetScan(ctx, assetScan, o.assetScanID)
 	if err != nil {
 		return fmt.Errorf("failed to patch asset scan: %w", err)
 	}
@@ -121,8 +132,8 @@ func (v *VMClarityPresenter) ExportSbomResult(ctx context.Context, res families.
 	return nil
 }
 
-func (v *VMClarityPresenter) ExportVulResult(ctx context.Context, res families.FamilyResult) error {
-	assetScan, err := v.client.GetAssetScan(ctx, v.assetScanID, apitypes.GetAssetScansAssetScanIDParams{})
+func (o *OpenClarityPresenter) ExportVulResult(ctx context.Context, res families.FamilyResult) error {
+	assetScan, err := o.client.GetAssetScan(ctx, o.assetScanID, apitypes.GetAssetScansAssetScanIDParams{})
 	if err != nil {
 		return fmt.Errorf("failed to get asset scan: %w", err)
 	}
@@ -163,7 +174,7 @@ func (v *VMClarityPresenter) ExportVulResult(ctx context.Context, res families.F
 		}
 	}
 
-	err = v.client.PatchAssetScan(ctx, assetScan, v.assetScanID)
+	err = o.client.PatchAssetScan(ctx, assetScan, o.assetScanID)
 	if err != nil {
 		return fmt.Errorf("failed to patch asset scan: %w", err)
 	}
@@ -171,8 +182,8 @@ func (v *VMClarityPresenter) ExportVulResult(ctx context.Context, res families.F
 	return nil
 }
 
-func (v *VMClarityPresenter) ExportSecretsResult(ctx context.Context, res families.FamilyResult) error {
-	assetScan, err := v.client.GetAssetScan(ctx, v.assetScanID, apitypes.GetAssetScansAssetScanIDParams{})
+func (o *OpenClarityPresenter) ExportSecretsResult(ctx context.Context, res families.FamilyResult) error {
+	assetScan, err := o.client.GetAssetScan(ctx, o.assetScanID, apitypes.GetAssetScansAssetScanIDParams{})
 	if err != nil {
 		return fmt.Errorf("failed to get asset scan: %w", err)
 	}
@@ -213,7 +224,7 @@ func (v *VMClarityPresenter) ExportSecretsResult(ctx context.Context, res famili
 		}
 	}
 
-	err = v.client.PatchAssetScan(ctx, assetScan, v.assetScanID)
+	err = o.client.PatchAssetScan(ctx, assetScan, o.assetScanID)
 	if err != nil {
 		return fmt.Errorf("failed to patch asset scan: %w", err)
 	}
@@ -244,8 +255,8 @@ func getInputScanStats(metadata families.FamilyMetadata) *[]apitypes.AssetScanIn
 	return &ret
 }
 
-func (v *VMClarityPresenter) ExportMalwareResult(ctx context.Context, res families.FamilyResult) error {
-	assetScan, err := v.client.GetAssetScan(ctx, v.assetScanID, apitypes.GetAssetScansAssetScanIDParams{})
+func (o *OpenClarityPresenter) ExportMalwareResult(ctx context.Context, res families.FamilyResult) error {
+	assetScan, err := o.client.GetAssetScan(ctx, o.assetScanID, apitypes.GetAssetScansAssetScanIDParams{})
 	if err != nil {
 		return fmt.Errorf("failed to get asset scan: %w", err)
 	}
@@ -288,15 +299,15 @@ func (v *VMClarityPresenter) ExportMalwareResult(ctx context.Context, res famili
 		}
 	}
 
-	if err = v.client.PatchAssetScan(ctx, assetScan, v.assetScanID); err != nil {
+	if err = o.client.PatchAssetScan(ctx, assetScan, o.assetScanID); err != nil {
 		return fmt.Errorf("failed to patch asset scan: %w", err)
 	}
 
 	return nil
 }
 
-func (v *VMClarityPresenter) ExportExploitsResult(ctx context.Context, res families.FamilyResult) error {
-	assetScan, err := v.client.GetAssetScan(ctx, v.assetScanID, apitypes.GetAssetScansAssetScanIDParams{})
+func (o *OpenClarityPresenter) ExportExploitsResult(ctx context.Context, res families.FamilyResult) error {
+	assetScan, err := o.client.GetAssetScan(ctx, o.assetScanID, apitypes.GetAssetScansAssetScanIDParams{})
 	if err != nil {
 		return fmt.Errorf("failed to get asset scan: %w", err)
 	}
@@ -337,7 +348,7 @@ func (v *VMClarityPresenter) ExportExploitsResult(ctx context.Context, res famil
 		}
 	}
 
-	err = v.client.PatchAssetScan(ctx, assetScan, v.assetScanID)
+	err = o.client.PatchAssetScan(ctx, assetScan, o.assetScanID)
 	if err != nil {
 		return fmt.Errorf("failed to patch asset scan: %w", err)
 	}
@@ -345,8 +356,8 @@ func (v *VMClarityPresenter) ExportExploitsResult(ctx context.Context, res famil
 	return nil
 }
 
-func (v *VMClarityPresenter) ExportMisconfigurationResult(ctx context.Context, res families.FamilyResult) error {
-	assetScan, err := v.client.GetAssetScan(ctx, v.assetScanID, apitypes.GetAssetScansAssetScanIDParams{})
+func (o *OpenClarityPresenter) ExportMisconfigurationResult(ctx context.Context, res families.FamilyResult) error {
+	assetScan, err := o.client.GetAssetScan(ctx, o.assetScanID, apitypes.GetAssetScansAssetScanIDParams{})
 	if err != nil {
 		return fmt.Errorf("failed to get asset scan: %w", err)
 	}
@@ -397,7 +408,7 @@ func (v *VMClarityPresenter) ExportMisconfigurationResult(ctx context.Context, r
 		}
 	}
 
-	err = v.client.PatchAssetScan(ctx, assetScan, v.assetScanID)
+	err = o.client.PatchAssetScan(ctx, assetScan, o.assetScanID)
 	if err != nil {
 		return fmt.Errorf("failed to patch asset scan: %w", err)
 	}
@@ -405,8 +416,8 @@ func (v *VMClarityPresenter) ExportMisconfigurationResult(ctx context.Context, r
 	return nil
 }
 
-func (v *VMClarityPresenter) ExportInfoFinderResult(ctx context.Context, res families.FamilyResult) error {
-	assetScan, err := v.client.GetAssetScan(ctx, v.assetScanID, apitypes.GetAssetScansAssetScanIDParams{})
+func (o *OpenClarityPresenter) ExportInfoFinderResult(ctx context.Context, res families.FamilyResult) error {
+	assetScan, err := o.client.GetAssetScan(ctx, o.assetScanID, apitypes.GetAssetScansAssetScanIDParams{})
 	if err != nil {
 		return fmt.Errorf("failed to get asset scan: %w", err)
 	}
@@ -457,7 +468,7 @@ func (v *VMClarityPresenter) ExportInfoFinderResult(ctx context.Context, res fam
 		}
 	}
 
-	err = v.client.PatchAssetScan(ctx, assetScan, v.assetScanID)
+	err = o.client.PatchAssetScan(ctx, assetScan, o.assetScanID)
 	if err != nil {
 		return fmt.Errorf("failed to patch asset scan: %w", err)
 	}
@@ -465,8 +476,8 @@ func (v *VMClarityPresenter) ExportInfoFinderResult(ctx context.Context, res fam
 	return nil
 }
 
-func (v *VMClarityPresenter) ExportRootkitResult(ctx context.Context, res families.FamilyResult) error {
-	assetScan, err := v.client.GetAssetScan(ctx, v.assetScanID, apitypes.GetAssetScansAssetScanIDParams{})
+func (o *OpenClarityPresenter) ExportRootkitResult(ctx context.Context, res families.FamilyResult) error {
+	assetScan, err := o.client.GetAssetScan(ctx, o.assetScanID, apitypes.GetAssetScansAssetScanIDParams{})
 	if err != nil {
 		return fmt.Errorf("failed to get asset scan: %w", err)
 	}
@@ -507,15 +518,15 @@ func (v *VMClarityPresenter) ExportRootkitResult(ctx context.Context, res famili
 		}
 	}
 
-	if err = v.client.PatchAssetScan(ctx, assetScan, v.assetScanID); err != nil {
+	if err = o.client.PatchAssetScan(ctx, assetScan, o.assetScanID); err != nil {
 		return fmt.Errorf("failed to patch asset scan: %w", err)
 	}
 
 	return nil
 }
 
-func (v *VMClarityPresenter) ExportPluginsResult(ctx context.Context, res families.FamilyResult) error {
-	assetScan, err := v.client.GetAssetScan(ctx, v.assetScanID, apitypes.GetAssetScansAssetScanIDParams{})
+func (o *OpenClarityPresenter) ExportPluginsResult(ctx context.Context, res families.FamilyResult) error {
+	assetScan, err := o.client.GetAssetScan(ctx, o.assetScanID, apitypes.GetAssetScansAssetScanIDParams{})
 	if err != nil {
 		return fmt.Errorf("failed to get asset scan: %w", err)
 	}
@@ -557,20 +568,10 @@ func (v *VMClarityPresenter) ExportPluginsResult(ctx context.Context, res famili
 		}
 	}
 
-	err = v.client.PatchAssetScan(ctx, assetScan, v.assetScanID)
+	err = o.client.PatchAssetScan(ctx, assetScan, o.assetScanID)
 	if err != nil {
 		return fmt.Errorf("failed to patch asset scan: %w", err)
 	}
 
 	return nil
-}
-
-func NewVMClarityPresenter(client *apiclient.Client, id AssetScanID) (*VMClarityPresenter, error) {
-	if client == nil {
-		return nil, errors.New("API client must not be nil")
-	}
-	return &VMClarityPresenter{
-		client:      client,
-		assetScanID: id,
-	}, nil
 }

--- a/cli/state/openclarity.go
+++ b/cli/state/openclarity.go
@@ -32,20 +32,31 @@ import (
 )
 
 const (
-	DefaultWaitForVolRetryInterval   = 15 * time.Second
-	effectiveScanConfigAnnotationKey = "openclarity.io/vmclarity-scanner/config"
+	DefaultWaitForVolRetryInterval             = 15 * time.Second
+	effectiveScanConfigAnnotationKey           = "openclarity.io/openclarity-scanner/config"
+	deprecatedeffectiveScanConfigAnnotationKey = "openclarity.io/vmclarity-scanner/config"
 )
 
 type AssetScanID = apitypes.AssetScanID
 
-type VMClarityState struct {
+type OpenClarityState struct {
 	client *apiclient.Client
 
 	assetScanID apitypes.AssetScanID
 }
 
+func NewOpenClarityState(client *apiclient.Client, id AssetScanID) (*OpenClarityState, error) {
+	if client == nil {
+		return nil, errors.New("API client must not be nil")
+	}
+	return &OpenClarityState{
+		client:      client,
+		assetScanID: id,
+	}, nil
+}
+
 // nolint:cyclop
-func (v *VMClarityState) WaitForReadyState(ctx context.Context) error {
+func (o *OpenClarityState) WaitForReadyState(ctx context.Context) error {
 	logger := log.GetLoggerFromContextOrDiscard(ctx)
 
 	timer := time.NewTicker(DefaultWaitForVolRetryInterval)
@@ -54,7 +65,7 @@ func (v *VMClarityState) WaitForReadyState(ctx context.Context) error {
 	for {
 		select {
 		case <-timer.C:
-			status, err := v.client.GetAssetScanStatus(ctx, v.assetScanID)
+			status, err := o.client.GetAssetScanStatus(ctx, o.assetScanID)
 			if err != nil {
 				logger.Errorf("failed to get asset scan status: %v", err)
 				break
@@ -79,8 +90,8 @@ func (v *VMClarityState) WaitForReadyState(ctx context.Context) error {
 	}
 }
 
-func (v *VMClarityState) MarkInProgress(ctx context.Context, config *scanner.Config) error {
-	assetScan, err := v.client.GetAssetScan(ctx, v.assetScanID, apitypes.GetAssetScansAssetScanIDParams{})
+func (o *OpenClarityState) MarkInProgress(ctx context.Context, config *scanner.Config) error {
+	assetScan, err := o.client.GetAssetScan(ctx, o.assetScanID, apitypes.GetAssetScansAssetScanIDParams{})
 	if err != nil {
 		return fmt.Errorf("failed to get asset scan: %w", err)
 	}
@@ -105,7 +116,7 @@ func (v *VMClarityState) MarkInProgress(ctx context.Context, config *scanner.Con
 		return fmt.Errorf("failed to add effective scan config annotation: %w", err)
 	}
 
-	err = v.client.PatchAssetScan(ctx, assetScan, v.assetScanID)
+	err = o.client.PatchAssetScan(ctx, assetScan, o.assetScanID)
 	if err != nil {
 		return fmt.Errorf("failed to patch asset scan: %w", err)
 	}
@@ -113,8 +124,8 @@ func (v *VMClarityState) MarkInProgress(ctx context.Context, config *scanner.Con
 	return nil
 }
 
-func (v *VMClarityState) MarkDone(ctx context.Context) error {
-	assetScan, err := v.client.GetAssetScan(ctx, v.assetScanID, apitypes.GetAssetScansAssetScanIDParams{})
+func (o *OpenClarityState) MarkDone(ctx context.Context) error {
+	assetScan, err := o.client.GetAssetScan(ctx, o.assetScanID, apitypes.GetAssetScansAssetScanIDParams{})
 	if err != nil {
 		return fmt.Errorf("failed to get asset scan: %w", err)
 	}
@@ -126,7 +137,7 @@ func (v *VMClarityState) MarkDone(ctx context.Context) error {
 		nil,
 	)
 
-	err = v.client.PatchAssetScan(ctx, assetScan, v.assetScanID)
+	err = o.client.PatchAssetScan(ctx, assetScan, o.assetScanID)
 	if err != nil {
 		return fmt.Errorf("failed to patch asset scan: %w", err)
 	}
@@ -134,8 +145,8 @@ func (v *VMClarityState) MarkDone(ctx context.Context) error {
 	return nil
 }
 
-func (v *VMClarityState) MarkFailed(ctx context.Context, errorMessage string) error {
-	assetScan, err := v.client.GetAssetScan(ctx, v.assetScanID, apitypes.GetAssetScansAssetScanIDParams{})
+func (o *OpenClarityState) MarkFailed(ctx context.Context, errorMessage string) error {
+	assetScan, err := o.client.GetAssetScan(ctx, o.assetScanID, apitypes.GetAssetScansAssetScanIDParams{})
 	if err != nil {
 		return fmt.Errorf("failed to get asset scan: %w", err)
 	}
@@ -147,7 +158,7 @@ func (v *VMClarityState) MarkFailed(ctx context.Context, errorMessage string) er
 		to.Ptr(errorMessage),
 	)
 
-	err = v.client.PatchAssetScan(ctx, assetScan, v.assetScanID)
+	err = o.client.PatchAssetScan(ctx, assetScan, o.assetScanID)
 	if err != nil {
 		return fmt.Errorf("failed to patch asset scan: %w", err)
 	}
@@ -155,33 +166,33 @@ func (v *VMClarityState) MarkFailed(ctx context.Context, errorMessage string) er
 	return nil
 }
 
-func (v *VMClarityState) MarkFamilyScanInProgress(ctx context.Context, familyType families.FamilyType) error {
+func (o *OpenClarityState) MarkFamilyScanInProgress(ctx context.Context, familyType families.FamilyType) error {
 	var err error
 	switch familyType {
 	case families.SBOM:
-		err = v.markSBOMScanInProgress(ctx)
+		err = o.markSBOMScanInProgress(ctx)
 	case families.Vulnerabilities:
-		err = v.markVulnerabilitiesScanInProgress(ctx)
+		err = o.markVulnerabilitiesScanInProgress(ctx)
 	case families.Secrets:
-		err = v.markSecretsScanInProgress(ctx)
+		err = o.markSecretsScanInProgress(ctx)
 	case families.Exploits:
-		err = v.markExploitsScanInProgress(ctx)
+		err = o.markExploitsScanInProgress(ctx)
 	case families.Misconfiguration:
-		err = v.markMisconfigurationsScanInProgress(ctx)
+		err = o.markMisconfigurationsScanInProgress(ctx)
 	case families.Rootkits:
-		err = v.markRootkitsScanInProgress(ctx)
+		err = o.markRootkitsScanInProgress(ctx)
 	case families.Malware:
-		err = v.markMalwareScanInProgress(ctx)
+		err = o.markMalwareScanInProgress(ctx)
 	case families.InfoFinder:
-		err = v.markInfoFinderScanInProgress(ctx)
+		err = o.markInfoFinderScanInProgress(ctx)
 	case families.Plugins:
-		err = v.markPluginsScanInProgress(ctx)
+		err = o.markPluginsScanInProgress(ctx)
 	}
 	return err
 }
 
-func (v *VMClarityState) markExploitsScanInProgress(ctx context.Context) error {
-	assetScan, err := v.client.GetAssetScan(ctx, v.assetScanID, apitypes.GetAssetScansAssetScanIDParams{})
+func (o *OpenClarityState) markExploitsScanInProgress(ctx context.Context) error {
+	assetScan, err := o.client.GetAssetScan(ctx, o.assetScanID, apitypes.GetAssetScansAssetScanIDParams{})
 	if err != nil {
 		return fmt.Errorf("failed to get asset scan: %w", err)
 	}
@@ -196,7 +207,7 @@ func (v *VMClarityState) markExploitsScanInProgress(ctx context.Context) error {
 		nil,
 	)
 
-	err = v.client.PatchAssetScan(ctx, assetScan, v.assetScanID)
+	err = o.client.PatchAssetScan(ctx, assetScan, o.assetScanID)
 	if err != nil {
 		return fmt.Errorf("failed to patch asset scan: %w", err)
 	}
@@ -204,8 +215,8 @@ func (v *VMClarityState) markExploitsScanInProgress(ctx context.Context) error {
 	return nil
 }
 
-func (v *VMClarityState) markSecretsScanInProgress(ctx context.Context) error {
-	assetScan, err := v.client.GetAssetScan(ctx, v.assetScanID, apitypes.GetAssetScansAssetScanIDParams{})
+func (o *OpenClarityState) markSecretsScanInProgress(ctx context.Context) error {
+	assetScan, err := o.client.GetAssetScan(ctx, o.assetScanID, apitypes.GetAssetScansAssetScanIDParams{})
 	if err != nil {
 		return fmt.Errorf("failed to get asset scan: %w", err)
 	}
@@ -220,7 +231,7 @@ func (v *VMClarityState) markSecretsScanInProgress(ctx context.Context) error {
 		nil,
 	)
 
-	err = v.client.PatchAssetScan(ctx, assetScan, v.assetScanID)
+	err = o.client.PatchAssetScan(ctx, assetScan, o.assetScanID)
 	if err != nil {
 		return fmt.Errorf("failed to patch asset scan: %w", err)
 	}
@@ -228,8 +239,8 @@ func (v *VMClarityState) markSecretsScanInProgress(ctx context.Context) error {
 	return nil
 }
 
-func (v *VMClarityState) markSBOMScanInProgress(ctx context.Context) error {
-	assetScan, err := v.client.GetAssetScan(ctx, v.assetScanID, apitypes.GetAssetScansAssetScanIDParams{})
+func (o *OpenClarityState) markSBOMScanInProgress(ctx context.Context) error {
+	assetScan, err := o.client.GetAssetScan(ctx, o.assetScanID, apitypes.GetAssetScansAssetScanIDParams{})
 	if err != nil {
 		return fmt.Errorf("failed to get asset scan: %w", err)
 	}
@@ -244,7 +255,7 @@ func (v *VMClarityState) markSBOMScanInProgress(ctx context.Context) error {
 		nil,
 	)
 
-	err = v.client.PatchAssetScan(ctx, assetScan, v.assetScanID)
+	err = o.client.PatchAssetScan(ctx, assetScan, o.assetScanID)
 	if err != nil {
 		return fmt.Errorf("failed to patch asset scan: %w", err)
 	}
@@ -252,8 +263,8 @@ func (v *VMClarityState) markSBOMScanInProgress(ctx context.Context) error {
 	return nil
 }
 
-func (v *VMClarityState) markVulnerabilitiesScanInProgress(ctx context.Context) error {
-	assetScan, err := v.client.GetAssetScan(ctx, v.assetScanID, apitypes.GetAssetScansAssetScanIDParams{})
+func (o *OpenClarityState) markVulnerabilitiesScanInProgress(ctx context.Context) error {
+	assetScan, err := o.client.GetAssetScan(ctx, o.assetScanID, apitypes.GetAssetScansAssetScanIDParams{})
 	if err != nil {
 		return fmt.Errorf("failed to get asset scan: %w", err)
 	}
@@ -268,7 +279,7 @@ func (v *VMClarityState) markVulnerabilitiesScanInProgress(ctx context.Context) 
 		nil,
 	)
 
-	err = v.client.PatchAssetScan(ctx, assetScan, v.assetScanID)
+	err = o.client.PatchAssetScan(ctx, assetScan, o.assetScanID)
 	if err != nil {
 		return fmt.Errorf("failed to patch asset scan: %w", err)
 	}
@@ -276,8 +287,8 @@ func (v *VMClarityState) markVulnerabilitiesScanInProgress(ctx context.Context) 
 	return nil
 }
 
-func (v *VMClarityState) markInfoFinderScanInProgress(ctx context.Context) error {
-	assetScan, err := v.client.GetAssetScan(ctx, v.assetScanID, apitypes.GetAssetScansAssetScanIDParams{})
+func (o *OpenClarityState) markInfoFinderScanInProgress(ctx context.Context) error {
+	assetScan, err := o.client.GetAssetScan(ctx, o.assetScanID, apitypes.GetAssetScansAssetScanIDParams{})
 	if err != nil {
 		return fmt.Errorf("failed to get asset scan: %w", err)
 	}
@@ -292,7 +303,7 @@ func (v *VMClarityState) markInfoFinderScanInProgress(ctx context.Context) error
 		nil,
 	)
 
-	err = v.client.PatchAssetScan(ctx, assetScan, v.assetScanID)
+	err = o.client.PatchAssetScan(ctx, assetScan, o.assetScanID)
 	if err != nil {
 		return fmt.Errorf("failed to patch asset scan: %w", err)
 	}
@@ -300,8 +311,8 @@ func (v *VMClarityState) markInfoFinderScanInProgress(ctx context.Context) error
 	return nil
 }
 
-func (v *VMClarityState) markMalwareScanInProgress(ctx context.Context) error {
-	assetScan, err := v.client.GetAssetScan(ctx, v.assetScanID, apitypes.GetAssetScansAssetScanIDParams{})
+func (o *OpenClarityState) markMalwareScanInProgress(ctx context.Context) error {
+	assetScan, err := o.client.GetAssetScan(ctx, o.assetScanID, apitypes.GetAssetScansAssetScanIDParams{})
 	if err != nil {
 		return fmt.Errorf("failed to get asset scan: %w", err)
 	}
@@ -316,7 +327,7 @@ func (v *VMClarityState) markMalwareScanInProgress(ctx context.Context) error {
 		nil,
 	)
 
-	err = v.client.PatchAssetScan(ctx, assetScan, v.assetScanID)
+	err = o.client.PatchAssetScan(ctx, assetScan, o.assetScanID)
 	if err != nil {
 		return fmt.Errorf("failed to patch asset scan: %w", err)
 	}
@@ -324,8 +335,8 @@ func (v *VMClarityState) markMalwareScanInProgress(ctx context.Context) error {
 	return nil
 }
 
-func (v *VMClarityState) markMisconfigurationsScanInProgress(ctx context.Context) error {
-	assetScan, err := v.client.GetAssetScan(ctx, v.assetScanID, apitypes.GetAssetScansAssetScanIDParams{})
+func (o *OpenClarityState) markMisconfigurationsScanInProgress(ctx context.Context) error {
+	assetScan, err := o.client.GetAssetScan(ctx, o.assetScanID, apitypes.GetAssetScansAssetScanIDParams{})
 	if err != nil {
 		return fmt.Errorf("failed to get asset scan: %w", err)
 	}
@@ -340,7 +351,7 @@ func (v *VMClarityState) markMisconfigurationsScanInProgress(ctx context.Context
 		nil,
 	)
 
-	err = v.client.PatchAssetScan(ctx, assetScan, v.assetScanID)
+	err = o.client.PatchAssetScan(ctx, assetScan, o.assetScanID)
 	if err != nil {
 		return fmt.Errorf("failed to patch asset scan: %w", err)
 	}
@@ -348,8 +359,8 @@ func (v *VMClarityState) markMisconfigurationsScanInProgress(ctx context.Context
 	return nil
 }
 
-func (v *VMClarityState) markRootkitsScanInProgress(ctx context.Context) error {
-	assetScan, err := v.client.GetAssetScan(ctx, v.assetScanID, apitypes.GetAssetScansAssetScanIDParams{})
+func (o *OpenClarityState) markRootkitsScanInProgress(ctx context.Context) error {
+	assetScan, err := o.client.GetAssetScan(ctx, o.assetScanID, apitypes.GetAssetScansAssetScanIDParams{})
 	if err != nil {
 		return fmt.Errorf("failed to get asset scan: %w", err)
 	}
@@ -364,7 +375,7 @@ func (v *VMClarityState) markRootkitsScanInProgress(ctx context.Context) error {
 		nil,
 	)
 
-	err = v.client.PatchAssetScan(ctx, assetScan, v.assetScanID)
+	err = o.client.PatchAssetScan(ctx, assetScan, o.assetScanID)
 	if err != nil {
 		return fmt.Errorf("failed to patch asset scan: %w", err)
 	}
@@ -372,8 +383,8 @@ func (v *VMClarityState) markRootkitsScanInProgress(ctx context.Context) error {
 	return nil
 }
 
-func (v *VMClarityState) markPluginsScanInProgress(ctx context.Context) error {
-	assetScan, err := v.client.GetAssetScan(ctx, v.assetScanID, apitypes.GetAssetScansAssetScanIDParams{})
+func (o *OpenClarityState) markPluginsScanInProgress(ctx context.Context) error {
+	assetScan, err := o.client.GetAssetScan(ctx, o.assetScanID, apitypes.GetAssetScansAssetScanIDParams{})
 	if err != nil {
 		return fmt.Errorf("failed to get asset scan: %w", err)
 	}
@@ -388,7 +399,7 @@ func (v *VMClarityState) markPluginsScanInProgress(ctx context.Context) error {
 		nil,
 	)
 
-	err = v.client.PatchAssetScan(ctx, assetScan, v.assetScanID)
+	err = o.client.PatchAssetScan(ctx, assetScan, o.assetScanID)
 	if err != nil {
 		return fmt.Errorf("failed to patch asset scan: %w", err)
 	}
@@ -396,8 +407,8 @@ func (v *VMClarityState) markPluginsScanInProgress(ctx context.Context) error {
 	return nil
 }
 
-func (v *VMClarityState) IsAborted(ctx context.Context) (bool, error) {
-	assetScan, err := v.client.GetAssetScan(ctx, v.assetScanID, apitypes.GetAssetScansAssetScanIDParams{
+func (o *OpenClarityState) IsAborted(ctx context.Context) (bool, error) {
+	assetScan, err := o.client.GetAssetScan(ctx, o.assetScanID, apitypes.GetAssetScansAssetScanIDParams{
 		Select: to.Ptr("id,status"),
 	})
 	if err != nil {
@@ -416,16 +427,6 @@ func (v *VMClarityState) IsAborted(ctx context.Context) (bool, error) {
 	return false, nil
 }
 
-func NewVMClarityState(client *apiclient.Client, id AssetScanID) (*VMClarityState, error) {
-	if client == nil {
-		return nil, errors.New("API client must not be nil")
-	}
-	return &VMClarityState{
-		client:      client,
-		assetScanID: id,
-	}, nil
-}
-
 func appendEffectiveScanConfigAnnotation(annotations *apitypes.Annotations, config *scanner.Config) (*apitypes.Annotations, error) {
 	var newAnnotations apitypes.Annotations
 	if annotations != nil {
@@ -433,15 +434,22 @@ func appendEffectiveScanConfigAnnotation(annotations *apitypes.Annotations, conf
 		for _, annotation := range *annotations {
 			if *annotation.Key == effectiveScanConfigAnnotationKey {
 				continue
+			} else if *annotation.Key == deprecatedeffectiveScanConfigAnnotationKey {
+				// change the key to the new one
+				annotation.Key = to.Ptr(effectiveScanConfigAnnotationKey)
+				continue
 			}
+
 			newAnnotations = append(newAnnotations, annotation)
 		}
 	}
+
 	// Add the new effective scan config annotation
 	configJSON, err := json.Marshal(config)
 	if err != nil {
 		return nil, fmt.Errorf("failed to marshal effective families config: %w", err)
 	}
+
 	newAnnotations = append(newAnnotations, apitypes.Annotations{
 		{
 			Key:   to.Ptr(effectiveScanConfigAnnotationKey),

--- a/cli/state/openclarity_test.go
+++ b/cli/state/openclarity_test.go
@@ -153,7 +153,37 @@ func Test_appendEffectiveScanConfigAnnotation(t *testing.T) {
 				},
 			},
 		},
+		{
+			name: "annotations contain deprecated effective scan config, overwrite it",
+			args: args{
+				annotations: &apitypes.Annotations{
+					{
+						Key:   to.Ptr(deprecatedeffectiveScanConfigAnnotationKey),
+						Value: to.Ptr("test"),
+					},
+				},
+				config: &scanner.Config{
+					SBOM: sbom.Config{
+						Enabled:       true,
+						AnalyzersList: []string{"syft"},
+						Inputs: []common.ScanInput{
+							{
+								Input:     "test",
+								InputType: "dir",
+							},
+						},
+					},
+				},
+			},
+			want: &apitypes.Annotations{
+				{
+					Key:   to.Ptr(effectiveScanConfigAnnotationKey),
+					Value: to.Ptr(effectiveScanConfigJSON),
+				},
+			},
+		},
 	}
+
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			g := NewGomegaWithT(t)

--- a/cli/test/boot/README.md
+++ b/cli/test/boot/README.md
@@ -1,29 +1,30 @@
-## Testing with Vagrant
+# Testing with Vagrant
 
 Vagrant is useful for testing locally the cloud-init functionality.
 First we need to install Vagrant and Virtualbox.
 
-```
+```bash
 brew install virtualbox virtualbox-extension-pack vagrant
 ```
 
 Starting the instance with Vagrant locally:
 
-```
+```bash
 cd scanner_boot_test/vagrant
 VAGRANT_EXPERIMENTAL="cloud_init,disks" vagrant up
 ```
 
 Starting an instance with cloud-init on AWS EC2:
 
-```
+```bash
 aws ec2 run-instances --image-id ami-abcd1234 --count 1 --instance-type m3.medium \
 --key-name my-key-pair --subnet-id subnet-abcd1234 --security-group-ids sg-abcd1234 \
 --user-data file://cloud-config.cfg
 ```
 
 On a running vagrant instance we can run the script manually for testing:
-```
+
+```bash
 cd scanner_boot_test/vagrant
 VAGRANT_EXPERIMENTAL="cloud_init,disks" vagrant up
 vagrant ssh

--- a/cli/test/boot/vagrant/cloud-config.cfg
+++ b/cli/test/boot/vagrant/cloud-config.cfg
@@ -3,7 +3,7 @@ package_upgrade: true
 packages:
   - docker.io
 write_files:
-  - path: /opt/vmclarity/scanconfig.json
+  - path: /opt/openclarity/scanconfig.json
     permissions: "0644"
     content: |
       {
@@ -29,23 +29,23 @@ write_files:
               }
           }
       }
-  - path: /etc/systemd/system/vmclarity-scanner.service
+  - path: /etc/systemd/system/openclarity-scanner.service
     permissions: "0644"
     content: |
       [Unit]
-      Description=VMClarity scanner job
+      Description=OpenClarity scanner job
       Requires=docker.service
       After=network.target docker.service
 
       [Service]
       Type=oneshot
-      WorkingDirectory=/opt/vmclarity
+      WorkingDirectory=/opt/openclarity
       ExecStartPre=docker pull busybox
-      ExecStart=docker run --rm --name %n -v /opt/vmclarity:/vmclarity busybox ls /vmclarity
+      ExecStart=docker run --rm --name %n -v /opt/openclarity:/openclarity busybox ls /openclarity
 
       [Install]
       WantedBy=multi-user.target
 runcmd:
   - [ systemctl, daemon-reload ]
   - [ systemctl, start, docker.service ]
-  - [ systemctl, start, vmclarity-scanner.service ]
+  - [ systemctl, start, openclarity-scanner.service ]


### PR DESCRIPTION
## Description

- This PR migrates the `convert` command from KubeClarity.
- While I was working on this, I changed `VMClarity` references to `OpenClarity` ones

## Type of Change

- [ ] Bug Fix
- [x] New Feature
- [ ] Breaking Change
- [x] Refactor
- [ ] Documentation
- [ ] Other (please describe)

## Checklist

- [x] I have read the [contributing guidelines](https://github.com/openclarity/openclarity/blob/main/CONTRIBUTING.md)
- [x] Existing issues have been referenced (where applicable)
- [x] I have verified this change is not present in other open pull requests
- [ ] Functionality is documented
- [x] All code style checks pass
- [x] New code contribution is covered by automated tests
- [x] All new and existing tests pass
