### PR TITLE
feat(ci): add support for self-hosted renovate

### DIFF
--- a/.github/workflows/dependencies.yml
+++ b/.github/workflows/dependencies.yml
@@ -1,0 +1,38 @@
+name: Dependencies
+
+on:
+  workflow_dispatch:
+  schedule:
+    # At 01:00 on Monday: https://crontab.guru/#0_1_*_*_1
+    - cron: '0 1 * * 1'
+
+jobs:
+  renovate:
+    name: Renovate Sync
+    runs-on: ubuntu-latest
+    steps:
+      - name: Authenticate Bot
+        id: auth
+        uses: actions/create-github-app-token@31c86eb3b33c9b601a1f60f98dcbfd1d70f379b4 # v1.10.3
+        with:
+          app-id: ${{ secrets.OPENCLARITY_BOT_APP_ID }}
+          private-key: ${{ secrets.OPENCLARITY_BOT_PRIVATE_KEY }}
+
+      - name: Checkout
+        uses: actions/checkout@692973e3d937129bcbf40652eb9f2f61becf3332 # v4.1.7
+
+      - name: Run Renovate
+        run: make renovate
+        env:
+          ## Discovery
+          # Renovate finds and creates PRs for all repos accessible by auth token.
+          # Since we auth only against this repo, no other repos can be accessed.
+          RENOVATE_AUTODISCOVER: "true"
+          RENOVATE_FORK_PROCESSING: "enabled"
+          ## Project sync
+          RENOVATE_PLATFORM: "github"
+          RENOVATE_PLATFORM_COMMIT: "true"
+          RENOVATE_TOKEN: ${{ steps.auth.outputs.token }}
+          GITHUB_COM_TOKEN: ${{ steps.auth.outputs.token }}
+          # Remove unused fields from PR description
+          RENOVATE_PR_BODY_TEMPLATE: "{{{header}}}{{{table}}}{{{warnings}}}{{{notes}}}{{{changelogs}}}"

--- a/.github/workflows/dependencies.yml
+++ b/.github/workflows/dependencies.yml
@@ -18,6 +18,11 @@ jobs:
           app-id: ${{ secrets.OPENCLARITY_BOT_APP_ID }}
           private-key: ${{ secrets.OPENCLARITY_BOT_PRIVATE_KEY }}
 
+      - name: Setup Node
+        uses: actions/setup-node@1e60f620b9541d16bece96c5465dc8ee9832be0b # v4.0.3
+        with:
+          node-version: 20
+
       - name: Checkout
         uses: actions/checkout@692973e3d937129bcbf40652eb9f2f61becf3332 # v4.1.7
 

--- a/makefile.d/20-tools.mk
+++ b/makefile.d/20-tools.mk
@@ -244,3 +244,15 @@ bin/multimod:
 	@if [ ! -d $(MULTIMOD_REPO_DIR) ]; then git clone https://github.com/open-telemetry/opentelemetry-go-build-tools --branch multimod/v$(MULTIMOD_VERSION) $(MULTIMOD_REPO_DIR); fi
 	@go build -C $(MULTIMOD_REPO_DIR)/multimod -o $(MULTIMOD_BIN) main.go
 	@rm -rf $(MULTIMOD_REPO_DIR)
+
+####
+##  Renovate CLI
+####
+
+# renovate: datasource=github-releases depName=renovatebot/renovate versioning=semver
+RENOVATE_VERSION := 38.55.4
+RENOVATE_INSTALL_DIR := $(BIN_DIR)/node
+RENOVATE_BIN := $(RENOVATE_INSTALL_DIR)/node_modules/.bin/renovate
+
+bin/renovate:
+	@npm install --silent --prefix $(RENOVATE_INSTALL_DIR) renovate@$(RENOVATE_VERSION)

--- a/renovate.json
+++ b/renovate.json
@@ -39,7 +39,6 @@
     "helmv3",
     "pip_setup"
   ],
-  "forkProcessing": "disabled",
   "labels": [
     "dependencies"
   ],


### PR DESCRIPTION
## Description

This PR adds support for using self-hosted Renovate to perform dependency sync. The benefit is that we can now define post-dependency update commands to e.g. format and regenerate code.

Renovate Bot will be replaced with OpenClarity Bot to track dependency data in GitHub.

## Type of Change

- [ ] Bug Fix
- [x] New Feature
- [ ] Breaking Change
- [ ] Refactor
- [ ] Documentation
- [ ] Other (please describe)

## Checklist

- [ ] I have read the [contributing guidelines](https://github.com/openclarity/openclarity/blob/main/CONTRIBUTING.md)
- [ ] Existing issues have been referenced (where applicable)
- [ ] I have verified this change is not present in other open pull requests
- [ ] Functionality is documented
- [ ] All code style checks pass
- [ ] New code contribution is covered by automated tests
- [ ] All new and existing tests pass
