### PR TITLE
fix: findings not processed

### DIFF
--- a/orchestrator/processor/assetscan/config.go
+++ b/orchestrator/processor/assetscan/config.go
@@ -23,7 +23,7 @@ import (
 
 const (
 	DefaultPollInterval     = 2 * time.Minute
-	DefaultReconcileTimeout = 5 * time.Minute
+	DefaultReconcileTimeout = 12 * time.Hour
 )
 
 type Config struct {

--- a/orchestrator/processor/assetscan/processor.go
+++ b/orchestrator/processor/assetscan/processor.go
@@ -130,6 +130,12 @@ func (asp *AssetScanProcessor) Reconcile(ctx context.Context, event AssetScanRec
 		}
 	}
 
+	// Processing into findings is a time-consuming operation, so pull the latest asset scan again from the API
+	assetScan, err = asp.client.GetAssetScan(ctx, event.AssetScanID, apitypes.GetAssetScansAssetScanIDParams{})
+	if err != nil {
+		return fmt.Errorf("failed to get asset scan from API: %w", err)
+	}
+
 	// Mark post-processing completed for this asset scan
 	assetScan.FindingsProcessed = to.Ptr(true)
 	err = asp.client.PatchAssetScan(ctx, assetScan, *assetScan.Id)


### PR DESCRIPTION
## Description

* Increase `AssetScanProcessor ` reconcile timeout to allow time for findings processing (e.g. in AWS an asset scan with 7k findings takes around 50min to process findings)
* Fix status transition failure (from `Done` to `Pending`) that was forcing us to reconcile findings twice due to an outdated `assetScan`  

## Type of Change

- [x] Bug Fix
- [ ] New Feature
- [ ] Breaking Change
- [ ] Refactor
- [ ] Documentation
- [ ] Other (please describe)

## Checklist

- [x] I have read the [contributing guidelines](https://github.com/openclarity/openclarity/blob/main/CONTRIBUTING.md)
- [ ] Existing issues have been referenced (where applicable)
- [x] I have verified this change is not present in other open pull requests
- [ ] Functionality is documented
- [x] All code style checks pass
- [ ] New code contribution is covered by automated tests
- [x] All new and existing tests pass
