### PR TITLE
fix(plugin): full scan run with plugins enabled 

### DIFF
--- a/e2e/config/config.go
+++ b/e2e/config/config.go
@@ -65,18 +65,16 @@ var FullScanFamiliesConfig = &apitypes.ScanFamiliesConfig{
 		Enabled:  to.Ptr(true),
 		Scanners: &[]string{"lynis", "cisdocker"},
 	},
-	// TODO: Enable plugins to full scan once it has been verified
-	// and working correctly with the orchestrator
-	// Plugins: &apitypes.PluginsConfig{
-	// 	Enabled:      to.Ptr(true),
-	// 	ScannersList: &[]string{"kics"},
-	// 	ScannersConfig: &map[string]apitypes.PluginScannerConfig{
-	// 		"kics": {
-	// 			Config:    to.Ptr(""),
-	// 			ImageName: to.Ptr("ghcr.io/openclarity/openclarity-plugin-kics:latest"),
-	// 		},
-	// 	},
-	// },
+	Plugins: &apitypes.PluginsConfig{
+		Enabled:      to.Ptr(true),
+		ScannersList: &[]string{"kics"},
+		ScannersConfig: &map[string]apitypes.PluginScannerConfig{
+			"kics": {
+				Config:    to.Ptr(""),
+				ImageName: to.Ptr(""),
+			},
+		},
+	},
 	Rootkits: &apitypes.RootkitsConfig{
 		Enabled:  to.Ptr(true),
 		Scanners: &[]string{"chkrootkit"},

--- a/e2e/config/config.go
+++ b/e2e/config/config.go
@@ -123,6 +123,10 @@ func TestSuiteParamsForEnv(t types.EnvironmentType) *TestSuiteParams {
 		// NOTE(paralta) Disabling syft https://github.com/anchore/syft/issues/1545
 		familiesConfig := FullScanFamiliesConfig
 		familiesConfig.Sbom.Analyzers = &[]string{"trivy", "windows"}
+
+		// NOTE(paralta) Disabling plugins since kics does not support oci-archive inputs
+		familiesConfig.Plugins.Enabled = to.Ptr(false)
+
 		return &TestSuiteParams{
 			ServicesReadyTimeout: 5 * time.Minute,
 			ScanTimeout:          5 * time.Minute,

--- a/e2e/full_scan_test.go
+++ b/e2e/full_scan_test.go
@@ -97,7 +97,7 @@ var _ = ginkgo.Describe("Running a full scan (exploits, info finder, malware, mi
 
 			reportFailedConfig.objects = append(
 				reportFailedConfig.objects,
-				APIObject{"assetScan", fmt.Sprintf("scan/id eq '%s'", *apiScanConfig.Id)},
+				APIObject{"assetScan", fmt.Sprintf("scan/id eq '%s'", *(*scans.Items)[0].Id)},
 			)
 
 			ginkgo.By("waiting until scan state changes to done")

--- a/e2e/full_scan_test.go
+++ b/e2e/full_scan_test.go
@@ -48,6 +48,14 @@ var _ = ginkgo.Describe("Running a full scan (exploits, info finder, malware, mi
 				return len(*assets.Items) == 1
 			}, DefaultTimeout, DefaultPeriod).Should(gomega.BeTrue())
 
+			// Set the plugin image name for kics
+			cfg.TestSuiteParams.FamiliesConfig.Plugins.ScannersConfig = &map[string]apitypes.PluginScannerConfig{
+				"kics": {
+					Config:    to.Ptr(""),
+					ImageName: to.Ptr(cfg.TestEnvConfig.Images.PluginKics),
+				},
+			}
+
 			ginkgo.By("applying a scan configuration")
 			apiScanConfig, err := client.PostScanConfig(
 				ctx,

--- a/plugins/runner/internal/runtimehandler/docker/handler.go
+++ b/plugins/runner/internal/runtimehandler/docker/handler.go
@@ -103,6 +103,7 @@ func (h *containerRuntimeHandler) Start(ctx context.Context) error {
 				fmt.Sprintf("%s=http://0.0.0.0:%s", plugin.EnvListenAddress, defaultInternalServerPort.Port()),
 			},
 			ExposedPorts: nat.PortSet{defaultInternalServerPort: struct{}{}},
+			User:         h.getUser(ctx),
 		},
 		&containertypes.HostConfig{
 			PortBindings: map[nat.Port][]nat.PortBinding{
@@ -371,6 +372,19 @@ func (h *containerRuntimeHandler) getScanInputDirMount(ctx context.Context) (*mo
 		Source: h.config.InputDir,
 		Target: runtimehandler.RemoteScanInputDirOverride, // override remote path
 	}, nil
+}
+
+func (h *containerRuntimeHandler) getUser(ctx context.Context) string {
+	// If the host is running in a container, get the user ID and group ID of the host container
+	// to read the mounted volume with the correct permissions.
+	if hostContainer, _ := h.client.GetHostContainer(ctx); hostContainer != nil {
+		userID := os.Getuid()
+		groupID := os.Getgid()
+
+		return fmt.Sprintf("%d:%d", userID, groupID)
+	}
+
+	return ""
 }
 
 // connectHostContainer connects host (container) to plugin network if in container mode

--- a/plugins/runner/internal/runtimehandler/docker/handler.go
+++ b/plugins/runner/internal/runtimehandler/docker/handler.go
@@ -348,9 +348,16 @@ func (h *containerRuntimeHandler) getScanInputDirMount(ctx context.Context) (*mo
 				continue
 			}
 
+			var source string
+			if p.Type == mount.TypeVolume {
+				source = p.Name // volume name
+			} else {
+				source = p.Source // actual source on the host
+			}
+
 			return &mount.Mount{
 				Type:   p.Type,
-				Source: p.Source,                                  // actual source on the host
+				Source: source,
 				Target: runtimehandler.RemoteScanInputDirOverride, // override remote path
 			}, nil
 		}


### PR DESCRIPTION
## Description

https://github.com/openclarity/openclarity/issues/760

* Fix mount definition when volume type mount is required
* Fix volume read permissions
* Enable plugins scan in full scan e2e test for Docker, AWS, GCP and Azure

✅ Tests successful on Docker and AWS

## Type of Change

- [x] Bug Fix
- [ ] New Feature
- [ ] Breaking Change
- [ ] Refactor
- [ ] Documentation
- [ ] Other (please describe)

## Checklist

- [x] I have read the [contributing guidelines](https://github.com/openclarity/openclarity/blob/main/CONTRIBUTING.md)
- [ ] Existing issues have been referenced (where applicable)
- [x] I have verified this change is not present in other open pull requests
- [ ] Functionality is documented
- [x] All code style checks pass
- [ ] New code contribution is covered by automated tests
- [x] All new and existing tests pass
