### PR TITLE
fix(workflow): reconfigure renovate dependency tracker

### DIFF
--- a/.github/workflows/dependencies.yml
+++ b/.github/workflows/dependencies.yml
@@ -41,3 +41,5 @@ jobs:
           GITHUB_COM_TOKEN: ${{ steps.auth.outputs.token }}
           # Remove unused fields from PR description
           RENOVATE_PR_BODY_TEMPLATE: "{{{header}}}{{{table}}}{{{warnings}}}{{{notes}}}{{{changelogs}}}"
+          RENOVATE_DEPENDENCY_DASHBOARD_HEADER: ""
+          RENOVATE_DEPENDENCY_DASHBOARD_O_S_V_VULNERABILITY_SUMMARY: "all"

--- a/Makefile
+++ b/Makefile
@@ -606,6 +606,7 @@ RENOVATE_OPTS ?=
 RENOVATE_OPTS += --platform $(or $(shell echo $$RENOVATE_PLATFORM),"local")
 
 # Enable running post-upgrade tasks
+RENOVATE_OPTS += --persist-repo-data 'true'
 RENOVATE_OPTS += --allowed-post-upgrade-commands '[".*"]'
 RENOVATE_OPTS += --post-upgrade-tasks '{"commands": ["make dep-tidy"], "executionMode": "branch"}'
 

--- a/renovate.json
+++ b/renovate.json
@@ -296,12 +296,10 @@
     "helmUpdateSubChartArchives"
   ],
   "prConcurrentLimit": 20,
+  "prHourlyLimit": 10,
   "printConfig": false,
-  "rebaseWhen": "conflicted",
+  "rebaseWhen": "behind-base-branch",
   "reviewersFromCodeOwners": true,
-  "schedule": [
-    "after 8am on Monday"
-  ],
   "semanticCommits": "enabled",
   "timezone": "Etc/UTC",
   "vulnerabilityAlerts": {


### PR DESCRIPTION
## Description

The PR limit per hour was 2 dependency updates + there was an option enabled to only create PRs when scheduled or set in the dashboard. Since we manage the schedule ourselves, we need to remove the renovate-service schedule (otherwise you can only have dep PRs created if you mark the checkbox in the dashboard). Another PR might be needed depending on how Renovate dashboard reacts with the new changes

## Type of Change

- [ ] Bug Fix
- [ ] New Feature
- [ ] Breaking Change
- [ ] Refactor
- [ ] Documentation
- [ ] Other (please describe)

## Checklist

- [ ] I have read the [contributing guidelines](https://github.com/openclarity/openclarity/blob/main/CONTRIBUTING.md)
- [ ] Existing issues have been referenced (where applicable)
- [ ] I have verified this change is not present in other open pull requests
- [ ] Functionality is documented
- [ ] All code style checks pass
- [ ] New code contribution is covered by automated tests
- [ ] All new and existing tests pass
