### PR TITLE
refactor(e2e): improve

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -213,7 +213,6 @@ e2e-aws: ## Run end-to-end test suite on AWS
 E2E_ENV_AZURE = $(E2E_ENV)
 E2E_ENV_AZURE += OPENCLARITY_E2E_PLATFORM=azure
 E2E_ENV_AZURE += OPENCLARITY_E2E_ENV_NAME=openclarity-e2e-test-azure
-E2E_ENV_AZURE += OPENCLARITY_E2E_AZURE_REGION=polandcentral
 
 .PHONY: e2e-azure
 e2e-azure: ## Run end-to-end test suite on Azure

--- a/Makefile
+++ b/Makefile
@@ -168,7 +168,9 @@ fix: bin/golangci-lint $(FIXGOMODULES) ## Fix linter errors in Go source code
 
 E2E_TARGETS =
 E2E_ENV =
-ifneq ($(CI),true)
+
+# Check if the CI environment is set to false to run the e2e tests with local images
+ifeq ($(CI),false)
 	E2E_TARGETS += docker
 	E2E_ENV += OPENCLARITY_E2E_APISERVER_IMAGE=$(DOCKER_REGISTRY)/openclarity-api-server:$(DOCKER_TAG)
 	E2E_ENV += OPENCLARITY_E2E_ORCHESTRATOR_IMAGE=$(DOCKER_REGISTRY)/openclarity-orchestrator:$(DOCKER_TAG)
@@ -195,6 +197,9 @@ E2E_ENV_K8S += OPENCLARITY_E2E_ENV_NAME=openclarity-e2e-test-k8s
 .PHONY: e2e-k8s
 e2e-k8s: $(E2E_TARGETS) ## Run end-to-end test suite on Kubernetes
 	$(E2E_ENV_K8S) $(E2E_COMMAND)
+
+# Run cloud end-to-end test suite with latest images in the registry, otherwise push images to registry is required
+E2E_ENV =
 
 E2E_ENV_AWS = $(E2E_ENV)
 E2E_ENV_AWS += OPENCLARITY_E2E_PLATFORM=aws

--- a/e2e/config/config.go
+++ b/e2e/config/config.go
@@ -122,7 +122,7 @@ func TestSuiteParamsForEnv(t types.EnvironmentType) *TestSuiteParams {
 			ScanTimeout:               40 * time.Minute,
 			FindingsProcessingTimeout: 120 * time.Minute,
 			Scope:                     fmt.Sprintf(scope, "tags"),
-			FamiliesConfig:            FullScanFamiliesConfig,
+			FamiliesConfig:            familiesConfig,
 		}
 	case types.EnvironmentTypeDocker:
 		return &TestSuiteParams{

--- a/e2e/config/config.go
+++ b/e2e/config/config.go
@@ -43,10 +43,11 @@ const (
 )
 
 type TestSuiteParams struct {
-	ServicesReadyTimeout time.Duration
-	ScanTimeout          time.Duration
-	Scope                string
-	FamiliesConfig       *apitypes.ScanFamiliesConfig
+	ServicesReadyTimeout      time.Duration
+	ScanTimeout               time.Duration
+	FindingsProcessingTimeout time.Duration
+	Scope                     string
+	FamiliesConfig            *apitypes.ScanFamiliesConfig
 }
 
 var FullScanFamiliesConfig = &apitypes.ScanFamiliesConfig{
@@ -105,10 +106,11 @@ func TestSuiteParamsForEnv(t types.EnvironmentType) *TestSuiteParams {
 		familiesConfig.Malware.Enabled = to.Ptr(false)
 
 		return &TestSuiteParams{
-			ServicesReadyTimeout: 10 * time.Minute,
-			ScanTimeout:          20 * time.Minute,
-			Scope:                fmt.Sprintf(scope, "tags"),
-			FamiliesConfig:       familiesConfig,
+			ServicesReadyTimeout:      10 * time.Minute,
+			ScanTimeout:               20 * time.Minute,
+			Scope:                     fmt.Sprintf(scope, "tags"),
+			FindingsProcessingTimeout: 10 * time.Minute,
+			FamiliesConfig:            familiesConfig,
 		}
 	case types.EnvironmentTypeAzure:
 		// NOTE(paralta) Disabling malware due to long scan times
@@ -116,17 +118,19 @@ func TestSuiteParamsForEnv(t types.EnvironmentType) *TestSuiteParams {
 		familiesConfig.Malware.Enabled = to.Ptr(false)
 
 		return &TestSuiteParams{
-			ServicesReadyTimeout: 20 * time.Minute,
-			ScanTimeout:          40 * time.Minute,
-			Scope:                fmt.Sprintf(scope, "tags"),
-			FamiliesConfig:       FullScanFamiliesConfig,
+			ServicesReadyTimeout:      20 * time.Minute,
+			ScanTimeout:               40 * time.Minute,
+			FindingsProcessingTimeout: 120 * time.Minute,
+			Scope:                     fmt.Sprintf(scope, "tags"),
+			FamiliesConfig:            FullScanFamiliesConfig,
 		}
 	case types.EnvironmentTypeDocker:
 		return &TestSuiteParams{
-			ServicesReadyTimeout: 5 * time.Minute,
-			ScanTimeout:          5 * time.Minute,
-			Scope:                fmt.Sprintf(scope, "labels"),
-			FamiliesConfig:       FullScanFamiliesConfig,
+			ServicesReadyTimeout:      5 * time.Minute,
+			ScanTimeout:               5 * time.Minute,
+			Scope:                     fmt.Sprintf(scope, "labels"),
+			FindingsProcessingTimeout: 10 * time.Minute,
+			FamiliesConfig:            FullScanFamiliesConfig,
 		}
 	case types.EnvironmentTypeKubernetes:
 		// NOTE(paralta) Disabling syft https://github.com/anchore/syft/issues/1545
@@ -137,10 +141,11 @@ func TestSuiteParamsForEnv(t types.EnvironmentType) *TestSuiteParams {
 		familiesConfig.Plugins.Enabled = to.Ptr(false)
 
 		return &TestSuiteParams{
-			ServicesReadyTimeout: 5 * time.Minute,
-			ScanTimeout:          5 * time.Minute,
-			Scope:                fmt.Sprintf(scope, "labels") + " and assetInfo/containerName eq 'alpine'",
-			FamiliesConfig:       familiesConfig,
+			ServicesReadyTimeout:      5 * time.Minute,
+			ScanTimeout:               5 * time.Minute,
+			Scope:                     fmt.Sprintf(scope, "labels") + " and assetInfo/containerName eq 'alpine'",
+			FindingsProcessingTimeout: 10 * time.Minute,
+			FamiliesConfig:            familiesConfig,
 		}
 	default:
 		return &TestSuiteParams{}

--- a/e2e/config/config.go
+++ b/e2e/config/config.go
@@ -100,13 +100,21 @@ func TestSuiteParamsForEnv(t types.EnvironmentType) *TestSuiteParams {
 
 	switch t {
 	case types.EnvironmentTypeAWS, types.EnvironmentTypeGCP:
+		// NOTE(paralta) Disabling malware due to long scan times
+		familiesConfig := FullScanFamiliesConfig
+		familiesConfig.Malware.Enabled = to.Ptr(false)
+
 		return &TestSuiteParams{
 			ServicesReadyTimeout: 10 * time.Minute,
 			ScanTimeout:          20 * time.Minute,
 			Scope:                fmt.Sprintf(scope, "tags"),
-			FamiliesConfig:       FullScanFamiliesConfig,
+			FamiliesConfig:       familiesConfig,
 		}
 	case types.EnvironmentTypeAzure:
+		// NOTE(paralta) Disabling malware due to long scan times
+		familiesConfig := FullScanFamiliesConfig
+		familiesConfig.Malware.Enabled = to.Ptr(false)
+
 		return &TestSuiteParams{
 			ServicesReadyTimeout: 20 * time.Minute,
 			ScanTimeout:          40 * time.Minute,

--- a/e2e/config/config_test.go
+++ b/e2e/config/config_test.go
@@ -172,10 +172,11 @@ func TestConfig(t *testing.T) {
 					},
 				},
 				TestSuiteParams: &TestSuiteParams{
-					ServicesReadyTimeout: 5 * time.Minute,
-					ScanTimeout:          5 * time.Minute,
-					Scope:                "assetInfo/labels/any(t: t/key eq 'scanconfig' and t/value eq 'test') and assetInfo/containerName eq 'alpine'",
-					FamiliesConfig:       kubernetesFamiliesConfig,
+					ServicesReadyTimeout:      5 * time.Minute,
+					ScanTimeout:               5 * time.Minute,
+					FindingsProcessingTimeout: 10 * time.Minute,
+					Scope:                     "assetInfo/labels/any(t: t/key eq 'scanconfig' and t/value eq 'test') and assetInfo/containerName eq 'alpine'",
+					FamiliesConfig:            kubernetesFamiliesConfig,
 				},
 				BenchmarkConfig: benchmark.Config{
 					Enabled:        false,
@@ -267,10 +268,11 @@ func TestConfig(t *testing.T) {
 					},
 				},
 				TestSuiteParams: &TestSuiteParams{
-					ServicesReadyTimeout: 5 * time.Minute,
-					ScanTimeout:          5 * time.Minute,
-					Scope:                "assetInfo/labels/any(t: t/key eq 'scanconfig' and t/value eq 'test')",
-					FamiliesConfig:       FullScanFamiliesConfig,
+					ServicesReadyTimeout:      5 * time.Minute,
+					ScanTimeout:               5 * time.Minute,
+					FindingsProcessingTimeout: 10 * time.Minute,
+					Scope:                     "assetInfo/labels/any(t: t/key eq 'scanconfig' and t/value eq 'test')",
+					FamiliesConfig:            FullScanFamiliesConfig,
 				},
 				BenchmarkConfig: benchmark.Config{
 					Enabled:        true,

--- a/e2e/full_scan_test.go
+++ b/e2e/full_scan_test.go
@@ -128,7 +128,7 @@ var _ = ginkgo.Describe("Running a full scan (exploits, info finder, malware, mi
 					}
 				}
 				return false
-			}, DefaultTimeout*2, DefaultPeriod).Should(gomega.BeTrue())
+			}, cfg.TestSuiteParams.FindingsProcessingTimeout, DefaultPeriod).Should(gomega.BeTrue())
 
 			ginkgo.By("waiting until findings trends dashboard is populated with vulnerabilities")
 			gomega.Eventually(func() bool {

--- a/e2e/kics_test.go
+++ b/e2e/kics_test.go
@@ -30,6 +30,7 @@ import (
 	"github.com/openclarity/openclarity/scanner/families"
 	"github.com/openclarity/openclarity/scanner/families/plugins/runner/config"
 	plugintypes "github.com/openclarity/openclarity/scanner/families/plugins/types"
+	"github.com/openclarity/openclarity/testenv/types"
 )
 
 const scannerPluginName = "kics"
@@ -49,6 +50,10 @@ func (n *Notifier) FamilyFinished(_ context.Context, res families.FamilyResult) 
 var _ = ginkgo.Describe("Running KICS scan", func() {
 	ginkgo.Context("which scans an openapi.yaml file", func() {
 		ginkgo.It("should finish successfully", func(ctx ginkgo.SpecContext) {
+			if cfg.TestEnvConfig.Platform != types.EnvironmentTypeDocker {
+				ginkgo.Skip("skipping test because it's not running on docker")
+			}
+
 			if cfg.TestEnvConfig.Images.PluginKics == "" {
 				ginkgo.Skip("KICS plugin image not provided")
 			}
@@ -108,6 +113,10 @@ var _ = ginkgo.Describe("Running KICS scan", func() {
 var _ = ginkgo.Describe("Running a KICS scan", func() {
 	ginkgo.Context("which scans an openapi.yaml file and has report-formats set to sarif", func() {
 		ginkgo.It("should finish successfully, and output both JSON and Sarif format as well as OpenClarity output", func(ctx ginkgo.SpecContext) {
+			if cfg.TestEnvConfig.Platform != types.EnvironmentTypeDocker {
+				ginkgo.Skip("skipping test because it's not running on docker")
+			}
+
 			if cfg.TestEnvConfig.Images.PluginKics == "" {
 				ginkgo.Skip("KICS plugin image not provided")
 			}

--- a/testenv/azure/asset.go
+++ b/testenv/azure/asset.go
@@ -37,10 +37,10 @@ const (
 )
 
 var imageReference = &armcompute.ImageReference{
-	Offer:     to.Ptr("0001-com-ubuntu-minimal-focal"),
+	Offer:     to.Ptr("0001-com-ubuntu-minimal-jammy"),
 	Publisher: to.Ptr("Canonical"),
-	SKU:       to.Ptr("minimal-20_04-lts"),
-	Version:   to.Ptr("20.04.202004230"),
+	SKU:       to.Ptr("minimal-22_04-lts"),
+	Version:   to.Ptr("22.04.202409030"),
 }
 
 func (e *AzureEnv) createAssetVM(ctx context.Context, location, resourceGroupName string) error {


### PR DESCRIPTION
## Description

* Run cloud end-to-end test suite with latest images in the registry
* Disable malware for cloud runs due to long scan times
* KICS e2e test will not run on a certain provider so only enable this test when for Docker
* Increase time to process findings for Azure
* Change VM image scanned on Azure 

## Type of Change

- [ ] Bug Fix
- [ ] New Feature
- [ ] Breaking Change
- [x] Refactor
- [ ] Documentation
- [ ] Other (please describe)

## Checklist

- [x] I have read the [contributing guidelines](https://github.com/openclarity/openclarity/blob/main/CONTRIBUTING.md)
- [ ] Existing issues have been referenced (where applicable)
- [x] I have verified this change is not present in other open pull requests
- [ ] Functionality is documented
- [x] All code style checks pass
- [ ] New code contribution is covered by automated tests
- [x] All new and existing tests pass
