### PR TITLE
test(e2e): assert presence of more finding types

### DIFF
--- a/e2e/full_scan_test.go
+++ b/e2e/full_scan_test.go
@@ -124,7 +124,7 @@ var _ = ginkgo.Describe("Running a full scan (exploits, info finder, malware, mi
 					return false
 				}
 				for _, v := range *riskiestAssets.Vulnerabilities {
-					if *v.CriticalVulnerabilitiesCount > 1 {
+					if *v.HighVulnerabilitiesCount > 1 {
 						return true
 					}
 				}
@@ -181,16 +181,17 @@ var _ = ginkgo.Describe("Running a full scan (exploits, info finder, malware, mi
 				return *findings.Count > 0
 			}, DefaultTimeout*2, DefaultPeriod).Should(gomega.BeTrue())
 
+			// TODO: Find or build an image with all types of findings to enable all the checks below
 			if cfg.TestEnvConfig.Platform == testenvtypes.EnvironmentTypeDocker || cfg.TestEnvConfig.Platform == testenvtypes.EnvironmentTypeKubernetes {
 				ginkgo.By("checking if the scan has findings from different families")
 				summary := (*scans.Items)[0].Summary
 				gomega.Expect(*summary.TotalExploits).To(gomega.BeNumerically(">", 0), "expected exploits to be found")
-				gomega.Expect(*summary.TotalMalware).To(gomega.BeNumerically(">", 0), "expected malware to be found")
-				gomega.Expect(*summary.TotalPlugins).To(gomega.BeNumerically(">", 0), "expected findings from plugins to be found")
-				gomega.Expect(*summary.TotalSecrets).To(gomega.BeNumerically(">", 0), "expected secrets to be found")
+				// gomega.Expect(*summary.TotalMalware).To(gomega.BeNumerically(">", 0), "expected malware to be found")
+				// gomega.Expect(*summary.TotalPlugins).To(gomega.BeNumerically(">", 0), "expected findings from plugins to be found")
+				// gomega.Expect(*summary.TotalSecrets).To(gomega.BeNumerically(">", 0), "expected secrets to be found")
 				gomega.Expect(*summary.TotalPackages).To(gomega.BeNumerically(">", 0), "expected packages to be found")
 				gomega.Expect(*summary.TotalRootkits).To(gomega.BeNumerically(">", 0), "expected rootkits to be found")
-				gomega.Expect(*summary.TotalInfoFinder).To(gomega.BeNumerically(">", 0), "expected info finder findings to be found")
+				// gomega.Expect(*summary.TotalInfoFinder).To(gomega.BeNumerically(">", 0), "expected info finder findings to be found")
 				gomega.Expect(*summary.TotalMisconfigurations).To(gomega.BeNumerically(">", 0), "expected misconfigurations to be found")
 			}
 

--- a/e2e/full_scan_test.go
+++ b/e2e/full_scan_test.go
@@ -26,6 +26,7 @@ import (
 	apitypes "github.com/openclarity/openclarity/api/types"
 	"github.com/openclarity/openclarity/core/to"
 	"github.com/openclarity/openclarity/e2e/benchmark"
+	testenvtypes "github.com/openclarity/openclarity/testenv/types"
 	uitypes "github.com/openclarity/openclarity/uibackend/types"
 )
 
@@ -179,6 +180,19 @@ var _ = ginkgo.Describe("Running a full scan (exploits, info finder, malware, mi
 				gomega.Expect(skipDBLockedErr(err)).NotTo(gomega.HaveOccurred())
 				return *findings.Count > 0
 			}, DefaultTimeout*2, DefaultPeriod).Should(gomega.BeTrue())
+
+			if cfg.TestEnvConfig.Platform == testenvtypes.EnvironmentTypeDocker || cfg.TestEnvConfig.Platform == testenvtypes.EnvironmentTypeKubernetes {
+				ginkgo.By("checking if the scan has findings from different families")
+				summary := (*scans.Items)[0].Summary
+				gomega.Expect(*summary.TotalExploits).To(gomega.BeNumerically(">", 0), "expected exploits to be found")
+				gomega.Expect(*summary.TotalMalware).To(gomega.BeNumerically(">", 0), "expected malware to be found")
+				gomega.Expect(*summary.TotalPlugins).To(gomega.BeNumerically(">", 0), "expected findings from plugins to be found")
+				gomega.Expect(*summary.TotalSecrets).To(gomega.BeNumerically(">", 0), "expected secrets to be found")
+				gomega.Expect(*summary.TotalPackages).To(gomega.BeNumerically(">", 0), "expected packages to be found")
+				gomega.Expect(*summary.TotalRootkits).To(gomega.BeNumerically(">", 0), "expected rootkits to be found")
+				gomega.Expect(*summary.TotalInfoFinder).To(gomega.BeNumerically(">", 0), "expected info finder findings to be found")
+				gomega.Expect(*summary.TotalMisconfigurations).To(gomega.BeNumerically(">", 0), "expected misconfigurations to be found")
+			}
 
 			if cfg.BenchmarkConfig.Enabled {
 				ginkgo.By("writing benchmark results to markdown file")

--- a/testenv/docker/asset/docker-compose.override.yml
+++ b/testenv/docker/asset/docker-compose.override.yml
@@ -1,6 +1,6 @@
 services:
   alpine:
-    image: alpine:3.18.2@sha256:82d1e9d7ed48a7523bdebc18cf6290bdb97b82302a8a9c27d4fe885949ea94d1
+    image: alpine:3.17.0@sha256:c0d488a800e4127c334ad20d61d7bc21b4097540327217dfab52262adc02380c
     command: ["sleep", "infinity"]
     networks:
       - asset

--- a/testenv/kubernetes/asset/deployment.go
+++ b/testenv/kubernetes/asset/deployment.go
@@ -60,7 +60,7 @@ func NewDeploymentFromConfig(config *Config) (*appsv1.Deployment, error) {
 					Containers: []corev1.Container{
 						{
 							Name:    "alpine",
-							Image:   "alpine:3.18.2",
+							Image:   "alpine:3.17.0@sha256:c0d488a800e4127c334ad20d61d7bc21b4097540327217dfab52262adc02380c",
 							Command: []string{"sleep", "infinity"},
 						},
 					},


### PR DESCRIPTION
## Description

<!-- Please provide a meaningful description of what this change will do, or is for. Bonus points for including links to
related issues, other PRs, or technical references and some before/after screenshots if the change affects the UI.

| Before | After |
| :---: | :---: |
| 🖼️ | 🖼️ |

Note that by _not_ including a description, you are asking reviewers to do extra work to understand the context of this
change, which may lead to your PR taking much longer to review, or result in it not being reviewed at all. -->

Adding assertions for findings of different families. We might build our own vulnerable image and use that as an asset to assert more later.

## Type of Change

- [ ] Bug Fix
- [X] New Feature
- [ ] Breaking Change
- [ ] Refactor
- [ ] Documentation
- [ ] Other (please describe)

## Checklist

- [X] I have read the [contributing guidelines](https://github.com/openclarity/openclarity/blob/main/CONTRIBUTING.md)
- [ ] Existing issues have been referenced (where applicable)
- [X] I have verified this change is not present in other open pull requests
- [ ] Functionality is documented
- [ ] All code style checks pass
- [ ] New code contribution is covered by automated tests
- [ ] All new and existing tests pass
