### PR TITLE
refactor(e2e): improve GCP e2e test env

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -192,7 +192,7 @@ e2e-docker: $(E2E_TARGETS) ## Run end-to-end test suite on Docker
 
 E2E_ENV_K8S = $(E2E_ENV)
 E2E_ENV_K8S += OPENCLARITY_E2E_PLATFORM=kubernetes
-E2E_ENV_K8S += OPENCLARITY_E2E_ENV_NAME=openclarity-e2e-test-k8s
+E2E_ENV_K8S += OPENCLARITY_E2E_ENV_NAME=testenv-k8s
 
 .PHONY: e2e-k8s
 e2e-k8s: $(E2E_TARGETS) ## Run end-to-end test suite on Kubernetes
@@ -203,7 +203,7 @@ E2E_ENV =
 
 E2E_ENV_AWS = $(E2E_ENV)
 E2E_ENV_AWS += OPENCLARITY_E2E_PLATFORM=aws
-E2E_ENV_AWS += OPENCLARITY_E2E_ENV_NAME=openclarity-e2e-test-aws
+E2E_ENV_AWS += OPENCLARITY_E2E_ENV_NAME=testenv-aws
 E2E_ENV_AWS += OPENCLARITY_E2E_AWS_REGION=eu-central-1
 
 .PHONY: e2e-aws
@@ -212,7 +212,7 @@ e2e-aws: ## Run end-to-end test suite on AWS
 
 E2E_ENV_AZURE = $(E2E_ENV)
 E2E_ENV_AZURE += OPENCLARITY_E2E_PLATFORM=azure
-E2E_ENV_AZURE += OPENCLARITY_E2E_ENV_NAME=openclarity-e2e-test-azure
+E2E_ENV_AZURE += OPENCLARITY_E2E_ENV_NAME=testenv-azure
 
 .PHONY: e2e-azure
 e2e-azure: ## Run end-to-end test suite on Azure
@@ -220,7 +220,7 @@ e2e-azure: ## Run end-to-end test suite on Azure
 
 E2E_ENV_GCP = $(E2E_ENV)
 E2E_ENV_GCP += OPENCLARITY_E2E_PLATFORM=gcp
-E2E_ENV_GCP += OPENCLARITY_E2E_ENV_NAME=openclarity-e2e-test-gcp
+E2E_ENV_GCP += OPENCLARITY_E2E_ENV_NAME=testenv-gcp
 
 .PHONY: e2e-gcp
 e2e-gcp: ## Run end-to-end test suite on GCP

--- a/e2e/config/config.go
+++ b/e2e/config/config.go
@@ -107,7 +107,7 @@ func TestSuiteParamsForEnv(t types.EnvironmentType) *TestSuiteParams {
 
 		return &TestSuiteParams{
 			ServicesReadyTimeout:      10 * time.Minute,
-			ScanTimeout:               20 * time.Minute,
+			ScanTimeout:               30 * time.Minute,
 			Scope:                     fmt.Sprintf(scope, "tags"),
 			FindingsProcessingTimeout: 10 * time.Minute,
 			FamiliesConfig:            familiesConfig,

--- a/e2e/config/config_test.go
+++ b/e2e/config/config_test.go
@@ -247,7 +247,7 @@ func TestConfig(t *testing.T) {
 						},
 					},
 					AWS: &awsenv.Config{
-						EnvName:        "openclarity-testenv",
+						EnvName:        "testenv",
 						Region:         "eu-central-1",
 						ScannerArch:    "x86_64",
 						PrivateKeyFile: "",
@@ -255,12 +255,12 @@ func TestConfig(t *testing.T) {
 					},
 					GCP: &gcpenv.Config{
 						ScannerArch:    "x86_64",
-						EnvName:        "openclarity-testenv",
+						EnvName:        "testenv",
 						PrivateKeyFile: "",
 						PublicKeyFile:  "",
 					},
 					Azure: &azureenv.Config{
-						EnvName:        "openclarity-testenv",
+						EnvName:        "testenv",
 						Region:         "eastus",
 						ScannerArch:    "x86_64",
 						PrivateKeyFile: "",

--- a/testenv/config.go
+++ b/testenv/config.go
@@ -33,7 +33,7 @@ import (
 )
 
 const (
-	DefaultEnvName  = "openclarity-testenv"
+	DefaultEnvName  = "testenv"
 	DefaultPlatform = types.EnvironmentTypeDocker
 )
 


### PR DESCRIPTION
## Description

<!-- Please provide a meaningful description of what this change will do, or is for. Bonus points for including links to
related issues, other PRs, or technical references and some before/after screenshots if the change affects the UI.

| Before | After |
| :---: | :---: |
| 🖼️ | 🖼️ |

Note that by _not_ including a description, you are asking reviewers to do extra work to understand the context of this
change, which may lead to your PR taking much longer to review, or result in it not being reviewed at all. -->

- shorten testenv names because some generated resource names in GCP would sometimes exceed a limit, causing the deployment to fail; also the `openclarity` in the name was redundant.
- increased timeout to ensure full test to finish

## Type of Change

- [ ] Bug Fix
- [ ] New Feature
- [ ] Breaking Change
- [X] Refactor
- [ ] Documentation
- [ ] Other (please describe)

## Checklist

- [X] I have read the [contributing guidelines](https://github.com/openclarity/openclarity/blob/main/CONTRIBUTING.md)
- [ ] Existing issues have been referenced (where applicable)
- [X] I have verified this change is not present in other open pull requests
- [ ] Functionality is documented
- [ ] All code style checks pass
- [ ] New code contribution is covered by automated tests
- [ ] All new and existing tests pass
