### PR TITLE
feat(k8s): use scanner image with arm64 support

### DIFF
--- a/provider/kubernetes/scanner/scanner.go
+++ b/provider/kubernetes/scanner/scanner.go
@@ -186,7 +186,7 @@ func (s *Scanner) runScannerJob(ctx context.Context, config *provider.ScanJobCon
 					InitContainers: []corev1.Container{
 						{
 							Name:    "download-asset",
-							Image:   "yauritux/busybox-curl:latest",
+							Image:   "curlimages/curl:latest",
 							Command: []string{"/bin/sh", "-c"},
 							Args:    []string{fmt.Sprintf("curl -v %s -o %s", sourceURL, archiveLocation)},
 							VolumeMounts: []corev1.VolumeMount{


### PR DESCRIPTION
## Description

Change image used to download assets to `curlimages/curl:latest` as suggested at https://github.com/openclarity/openclarity/issues/886

Cheers to @duckman for finding and reporting this issue!

## Type of Change

- [x] Bug Fix
- [ ] New Feature
- [ ] Breaking Change
- [ ] Refactor
- [ ] Documentation
- [ ] Other (please describe)

## Checklist

- [x] I have read the [contributing guidelines](https://github.com/openclarity/openclarity/blob/main/CONTRIBUTING.md)
- [ ] Existing issues have been referenced (where applicable)
- [x] I have verified this change is not present in other open pull requests
- [ ] Functionality is documented
- [x] All code style checks pass
- [ ] New code contribution is covered by automated tests
- [x] All new and existing tests pass
