### PR TITLE
fix(cli): check SBOM result before writing

### DIFF
--- a/cli/presenter/writer_test.go
+++ b/cli/presenter/writer_test.go
@@ -1,0 +1,100 @@
+// Copyright © 2024 Cisco Systems, Inc. and its affiliates.
+// All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package presenter
+
+import (
+	"os"
+	"reflect"
+	"testing"
+)
+
+func TestConsoleWriter(t *testing.T) {
+	writer := &ConsoleWriter{Output: os.Stdout}
+
+	tests := []struct {
+		name   string
+		b      []byte
+		prefix string
+		want   error
+	}{
+		{
+			name:   "nil bytes no error",
+			b:      nil,
+			prefix: "sbom",
+			want:   nil,
+		},
+		{
+			name:   "empty bytes no error",
+			b:      []byte{},
+			prefix: "sbom",
+			want:   nil,
+		},
+		{
+			name:   "test content no error",
+			b:      []byte("test"),
+			prefix: "sbom",
+			want:   nil,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := writer.Write(tt.b, tt.prefix); !reflect.DeepEqual(got, tt.want) {
+				t.Errorf("ConsoleWriter.Write() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestFileWriter(t *testing.T) {
+	writer := &FileWriter{Path: "."}
+
+	tests := []struct {
+		name     string
+		b        []byte
+		filename string
+		want     error
+	}{
+		{
+			name:     "nil bytes no error",
+			b:        nil,
+			filename: "sbom.cdx",
+			want:     nil,
+		},
+		{
+			name:     "empty bytes no error",
+			b:        []byte{},
+			filename: "sbom.cdx",
+			want:     nil,
+		},
+		{
+			name:     "test content no error",
+			b:        []byte("test"),
+			filename: "sbom.cdx",
+			want:     nil,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := writer.Write(tt.b, tt.filename); !reflect.DeepEqual(got, tt.want) {
+				t.Errorf("FileWriter.Write() = %v, want %v", got, tt.want)
+			}
+		})
+		// cleanup
+		os.Remove(tt.filename)
+	}
+}

--- a/scanner/families/sbom/types/result.go
+++ b/scanner/families/sbom/types/result.go
@@ -42,9 +42,12 @@ func (r *Result) EncodeToBytes(outputFormat string) ([]byte, error) {
 		return nil, fmt.Errorf("unable to parse output format: %w", err)
 	}
 
-	bomBytes, err := converter.CycloneDxToBytes(r.SBOM, f)
-	if err != nil {
-		return nil, fmt.Errorf("unable to encode results to bytes: %w", err)
+	bomBytes := []byte{}
+	if r.SBOM != nil {
+		bomBytes, err = converter.CycloneDxToBytes(r.SBOM, f)
+		if err != nil {
+			return nil, fmt.Errorf("unable to encode results to bytes: %w", err)
+		}
 	}
 
 	return bomBytes, nil


### PR DESCRIPTION
## Description

<!-- Please provide a meaningful description of what this change will do, or is for. Bonus points for including links to
related issues, other PRs, or technical references and some before/after screenshots if the change affects the UI.

| Before | After |
| :---: | :---: |
| 🖼️ | 🖼️ |

Note that by _not_ including a description, you are asking reviewers to do extra work to understand the context of this
change, which may lead to your PR taking much longer to review, or result in it not being reviewed at all. -->

Fixes #885 

We can now return an empty byte slice from the parser if there are no SBOM results.

## Type of Change

- [X] Bug Fix
- [ ] New Feature
- [ ] Breaking Change
- [ ] Refactor
- [ ] Documentation
- [ ] Other (please describe)

## Checklist

- [X] I have read the [contributing guidelines](https://github.com/openclarity/openclarity/blob/main/CONTRIBUTING.md)
- [X] Existing issues have been referenced (where applicable)
- [X] I have verified this change is not present in other open pull requests
- [ ] Functionality is documented
- [ ] All code style checks pass
- [ ] New code contribution is covered by automated tests
- [ ] All new and existing tests pass
