### PR TITLE
fix(ui): Fixed issue with blank page when `image` information is missed in assetInfo

### DIFF
--- a/ui/src/layout/AssetScans/AssetScansTable.jsx
+++ b/ui/src/layout/AssetScans/AssetScansTable.jsx
@@ -53,7 +53,7 @@ const AssetScansTable = () => {
         accessor: (assetScan) =>
           assetScan.asset.assetInfo.location ||
           assetScan.asset.assetInfo.repoDigests?.[0] ||
-          assetScan.asset.assetInfo.image.repoDigests?.[0],
+          assetScan.asset.assetInfo.image?.repoDigests?.[0],
       },
       {
         Header: "Scan name",

--- a/ui/src/layout/Assets/AssetsForFindingTable.jsx
+++ b/ui/src/layout/Assets/AssetsForFindingTable.jsx
@@ -120,7 +120,7 @@ const AssetsForFindingTable = (props) => {
         accessor: (original) =>
           original.asset.assetInfo.location ||
           original.asset.assetInfo.repoDigests?.[0] ||
-          original.asset.assetInfo.image.repoDigests?.[0],
+          original.asset.assetInfo.image?.repoDigests?.[0],
       },
       {
         Header: "Last Seen",

--- a/ui/src/layout/Assets/AssetsTable.jsx
+++ b/ui/src/layout/Assets/AssetsTable.jsx
@@ -96,7 +96,7 @@ const AssetsTable = () => {
         accessor: (original) =>
           original.assetInfo.location ||
           original.assetInfo.repoDigests?.[0] ||
-          original.assetInfo.image.repoDigests?.[0],
+          original.assetInfo.image?.repoDigests?.[0],
       },
       {
         Header: "Last Seen",


### PR DESCRIPTION
## Description

Fixed issue with broken UI app when assets don't have image information
#906 

| Before | After |
| :---: | :---: |
|![image](https://github.com/user-attachments/assets/cb6b0748-26fd-4feb-a2a2-744f7eee0af1)  | ![image](https://github.com/user-attachments/assets/f353c0f7-5264-476b-b18c-c9fbcfcd5f75) ![image](https://github.com/user-attachments/assets/da137ec6-33cd-4309-abdd-3055c8c8562d) |


## Type of Change

- [X] Bug Fix
- [ ] New Feature
- [ ] Breaking Change
- [ ] Refactor
- [ ] Documentation
- [ ] Other (please describe)

## Checklist

- [X] I have read the [contributing guidelines](https://github.com/openclarity/openclarity/blob/main/CONTRIBUTING.md)
- [X] Existing issues have been referenced (where applicable)
- [X] I have verified this change is not present in other open pull requests
- [X] Functionality is documented
- [x] All code style checks pass
- [x] New code contribution is covered by automated tests
- [x] All new and existing tests pass
