### PR TITLE
fix(helm): installation error with externalPostgresql

### DIFF
--- a/installation/kubernetes/helm/openclarity/templates/apiserver/deployment.yaml
+++ b/installation/kubernetes/helm/openclarity/templates/apiserver/deployment.yaml
@@ -69,17 +69,17 @@ spec:
             - name: OPENCLARITY_APISERVER_DB_NAME
               valueFrom:
                 secretKeyRef:
-                  name: {{ .Values.apiserver.database.externalPostgresql.auth.existingSecret }} }}
+                  name: {{ .Values.apiserver.database.externalPostgresql.auth.existingSecret }}
                   key: database
             - name: OPENCLARITY_APISERVER_DB_USER
               valueFrom:
                 secretKeyRef:
-                  name: {{ .Values.apiserver.database.externalPostgresql.auth.existingSecret }} }}
+                  name: {{ .Values.apiserver.database.externalPostgresql.auth.existingSecret }}
                   key: username
             - name: OPENCLARITY_APISERVER_DB_PASS
               valueFrom:
                 secretKeyRef:
-                  name: {{ .Values.apiserver.database.externalPostgresql.auth.existingSecret }} }}
+                  name: {{ .Values.apiserver.database.externalPostgresql.auth.existingSecret }}
                   key: password
           {{- else if .Values.apiserver.database.sqlite.enabled }}
             - name: OPENCLARITY_APISERVER_DATABASE_DRIVER


### PR DESCRIPTION
Fix the following error due to extra curly brackets:

│     * Deployment.apps "openclarity-apiserver" is invalid: [spec.template.spec.containers[0].env[3].valueFrom.secretKeyRef.name: Invalid value: "openclarity }}": a lowercase RFC 1123 subdomain must consist of l │

## Description

<!-- Please provide a meaningful description of what this change will do, or is for. Bonus points for including links to
related issues, other PRs, or technical references and some before/after screenshots if the change affects the UI.

| Before | After |
| :---: | :---: |
| 🖼️ | 🖼️ |

Note that by _not_ including a description, you are asking reviewers to do extra work to understand the context of this
change, which may lead to your PR taking much longer to review, or result in it not being reviewed at all. -->

## Type of Change

- [x] Bug Fix
- [ ] New Feature
- [ ] Breaking Change
- [ ] Refactor
- [ ] Documentation
- [ ] Other (please describe)

## Checklist

- [x] I have read the [contributing guidelines](https://github.com/openclarity/openclarity/blob/main/CONTRIBUTING.md)
- [x] Existing issues have been referenced (where applicable)
- [x] I have verified this change is not present in other open pull requests
- [x] Functionality is documented
- [x] All code style checks pass
- [x] New code contribution is covered by automated tests
- [x] All new and existing tests pass
