### PR TITLE
Reintroduce new ingress.

### DIFF
--- a/installation/kubernetes/helm/openclarity/templates/gateway/_helpers.tpl
+++ b/installation/kubernetes/helm/openclarity/templates/gateway/_helpers.tpl
@@ -31,3 +31,13 @@ Create the name of the service account to use
     {{ default "default" .Values.gateway.serviceAccount.name }}
 {{- end -}}
 {{- end -}}
+
+{{/*
+Kubernetes standard labels for gateway Ingress
+*/}}
+{{- define "openclarity.gateway.ingress.labels.standard" -}}
+{{ include "openclarity.labels.standard" . }}
+{{ if .Values.gateway.ingress.labels -}}
+{{ toYaml .Values.gateway.ingress.labels }}
+{{- end -}}
+{{- end -}}

--- a/installation/kubernetes/helm/openclarity/templates/gateway/ingress.yaml
+++ b/installation/kubernetes/helm/openclarity/templates/gateway/ingress.yaml
@@ -1,0 +1,44 @@
+{{- if .Values.gateway.ingress.enabled -}}
+{{- $servicePort := .Values.gateway.service.ports.http -}}
+{{- $gatewayServiceName := include "openclarity.gateway.name" . -}}
+apiVersion: networking.k8s.io/v1
+kind: Ingress
+metadata:
+  name: {{ $gatewayServiceName }}-ingress
+  namespace: {{ .Release.Namespace | quote }}
+  labels:
+    {{- include "openclarity.gateway.ingress.labels.standard" . | nindent 4 }}
+  {{- if .Values.gateway.ingress.annotations }}
+  annotations:
+    {{- .Values.gateway.ingress.annotations | toYaml | nindent 4 }}
+  {{- end }}
+spec:
+{{- if .Values.gateway.ingress.tls }}
+  tls:
+  {{- range .Values.gateway.ingress.tls }}
+    - hosts:
+      {{- range .hosts }}
+        - {{ . | quote }}
+      {{- end }}
+      secretName: {{ .secretName }}
+  {{- end }}
+{{- end }}
+{{- if .Values.gateway.ingress.ingressClassName }}
+  ingressClassName: {{ .Values.gateway.ingress.ingressClassName }}
+{{- end }}
+  rules:
+  {{- range .Values.gateway.ingress.hosts }}
+    - host: {{ .host | quote }}
+      http:
+        paths:
+        {{- range (.paths | default (list (dict "pathType" "Prefix" "path" "/"))) }}
+          - path: {{ .path }}
+            pathType: {{ .pathType }}
+            backend:
+              service:
+                name: {{ $gatewayServiceName }}
+                port:
+                  number: {{ $servicePort }}
+        {{- end }}
+  {{- end }}
+{{- end }}

--- a/installation/kubernetes/helm/openclarity/values.yaml
+++ b/installation/kubernetes/helm/openclarity/values.yaml
@@ -452,6 +452,31 @@ gateway:
     # local endpoints.
     externalTrafficPolicy: Cluster
 
+  ingress:
+    # Be careful when using ingress. As there is no authentication on Kubeclarity yet, your instance may be accessible.
+    # Make sure the ingress remains internal if you decide to enable it.
+    enabled: false
+    labels: {}
+    annotations: {}
+
+    # Optionally use ingressClassName instead of deprecated annotation.
+    # See: https://kubernetes.io/docs/concepts/services-networking/ingress/#deprecated-annotation
+    ingressClassName: ""
+
+    hosts:
+      # hostname you want to use
+      - host: chart-example.local
+        # paths will default to:
+        # paths:
+        #   - pathType: Prefix
+        #     path: /
+        paths: []
+
+    tls: []
+    #  - secretName: chart-example-tls
+    #    hosts:
+    #      - chart-example.local
+
 postgresql:
   image:
     # -- Postgresql container registry


### PR DESCRIPTION
## Description

Add possibility to add ingress to gateway as was the case with the kubeclarity repository. Should have all options one would need, like annotatinos and labels to be able to customize things like whitelisting, basic auth and TLS.

Not sure about tests, i have ran lint and such, and have tested the output with different values. Not sure if there is any way to do more testing automated right now.

Fixes #916

Example ingress resource generated:
```

# Source: openclarity/templates/gateway/ingress.yaml
apiVersion: networking.k8s.io/v1
kind: Ingress
metadata:
  name: release-name-openclarity-gateway-ingress
  namespace: "default"
  labels:
    app.kubernetes.io/name: openclarity
    app.kubernetes.io/instance: release-name
    app.kubernetes.io/managed-by: Helm
    helm.sh/chart: openclarity-0.0.0
    app.kubernetes.io/version: "latest"
    example.com/testlabel: testvalue
  annotations:
    example.com/testannotation: testvalue
spec:
  ingressClassName: testClassName
  rules:
    - host: "chart-example.local"
      http:
        paths:
          - path: /
            pathType: Prefix
            backend:
              service:
                name: release-name-openclarity-gateway
                port:
                  number: 80
    - host: "test.local"
      http:
        paths:
          - path: /test
            pathType: Prefix
            backend:
              service:
                name: release-name-openclarity-gateway
                port:
                  number: 80
```

This is based on the following values:
```
gateway:
  ingress:
    # Be careful when using ingress. As there is no authentication on Kubeclarity yet, your instance may be accessible.
    # Make sure the ingress remains internal if you decide to enable it.
    enabled: true
    labels:
      example.com/testlabel: "testvalue"
    annotations:
      example.com/testannotation: "testvalue"

    # Optionally use ingressClassName instead of deprecated annotation.
    # See: https://kubernetes.io/docs/concepts/services-networking/ingress/#deprecated-annotation
    ingressClassName: "testClassName"

    hosts:
      # hostname you want to use
      - host: chart-example.local
        # paths will default to:
        # paths:
        #   - pathType: Prefix
        #     path: /
        paths: []
      - host: test.local
        paths:
          - pathType: Prefix
            path: /test

    tls: []
    #  - secretName: chart-example-tls
    #    hosts:
    #      - chart-example.local
```

## Type of Change

- [ ] Bug Fix
- [x] New Feature
- [ ] Breaking Change
- [ ] Refactor
- [ ] Documentation
- [ ] Other (please describe)

## Checklist

- [x] I have read the [contributing guidelines](https://github.com/openclarity/openclarity/blob/main/CONTRIBUTING.md)
- [x] Existing issues have been referenced (where applicable)
- [x] I have verified this change is not present in other open pull requests
- [ ] Functionality is documented
- [x] All code style checks pass
- [ ] New code contribution is covered by automated tests
- [ ] All new and existing tests pass
