### PR TITLE
ci: free disk space for dependencies workflow

### DIFF
--- a/.github/workflows/dependencies.yml
+++ b/.github/workflows/dependencies.yml
@@ -18,6 +18,19 @@ jobs:
           app-id: ${{ secrets.OPENCLARITY_BOT_APP_ID }}
           private-key: ${{ secrets.OPENCLARITY_BOT_PRIVATE_KEY }}
 
+      - name: Free Disk Space (Ubuntu)
+        uses: jlumbroso/free-disk-space@v1.3.1
+        with:
+          # removes all pre-cached tools (Node, Go, Python, Ruby, ...)
+          tool-cache: true
+          # remove android runtime, dotnet runtime, haskell runtime, large packages, docker images, swap storage
+          android: true
+          dotnet: true
+          haskell: true
+          large-packages: true
+          docker-images: true
+          swap-storage: true
+
       - name: Setup Node
         uses: actions/setup-node@39370e3970a6d050c480ffad4ff0ed4d3fdee5af # v4.1.0
         with:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -17,6 +17,19 @@ jobs:
       - name: Checkout
         uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
 
+      - name: Free Disk Space (Ubuntu)
+        uses: jlumbroso/free-disk-space@v1.3.1
+        with:
+          # removes all pre-cached tools (Node, Go, Python, Ruby, ...)
+          tool-cache: true
+          # remove android runtime, dotnet runtime, haskell runtime, large packages, docker images, swap storage
+          android: true
+          dotnet: true
+          haskell: true
+          large-packages: true
+          docker-images: true
+          swap-storage: true
+
       - name: Set up Go
         uses: actions/setup-go@3041bf56c941b39c61721a86cd11f3bb1338122a # v5.2.0
         with:
@@ -24,24 +37,6 @@ jobs:
           # as it provides better flexibility like setting the cache key which reduces cache misses significantly.
           cache: false
           go-version-file: '.go-version'
-
-      - name: Free up disk space
-        run: |
-          df -h
-
-          # Remove .NET related tooling
-          sudo du -sh /usr/share/dotnet
-          sudo rm -rf /usr/share/dotnet
-
-          # Remove Android related tooling
-          sudo du -sh /usr/local/lib/android
-          sudo rm -rf /usr/local/lib/android
-
-          # Remove CodeQL
-          sudo du -sh /opt/hostedtoolcache/CodeQL
-          sudo rm -rf /opt/hostedtoolcache/CodeQL
-
-          df -h
 
       - name: Setup Go caching
         uses: actions/cache@1bd1e32a3bdc45362d1e726936510720a7c30a57 # v4.2.0

--- a/.github/workflows/reusable-end-to-end-testing.yml
+++ b/.github/workflows/reusable-end-to-end-testing.yml
@@ -24,6 +24,19 @@ jobs:
       - name: Checkout
         uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
 
+      - name: Free Disk Space (Ubuntu)
+        uses: jlumbroso/free-disk-space@v1.3.1
+        with:
+          # removes all pre-cached tools (Node, Go, Python, Ruby, ...)
+          tool-cache: true
+          # remove android runtime, dotnet runtime, haskell runtime, large packages, docker images, swap storage
+          android: true
+          dotnet: true
+          haskell: true
+          large-packages: true
+          docker-images: true
+          swap-storage: true
+
       - name: Set up Go
         uses: actions/setup-go@3041bf56c941b39c61721a86cd11f3bb1338122a # v5.2.0
         with:
@@ -31,24 +44,6 @@ jobs:
           # as it provides better flexibility like setting the cache key which reduces cache misses significantly.
           cache: false
           go-version-file: '.go-version'
-
-      - name: Free up disk space
-        run: |
-          df -h
-
-          # Remove .NET related tooling
-          sudo du -sh /usr/share/dotnet
-          sudo rm -rf /usr/share/dotnet
-
-          # Remove Android related tooling
-          sudo du -sh /usr/local/lib/android
-          sudo rm -rf /usr/local/lib/android
-
-          # Remove CodeQL
-          sudo du -sh /opt/hostedtoolcache/CodeQL
-          sudo rm -rf /opt/hostedtoolcache/CodeQL
-
-          df -h
 
       - name: Setup Go caching
         uses: actions/cache@1bd1e32a3bdc45362d1e726936510720a7c30a57 # v4.2.0

--- a/.github/workflows/reusable-verification.yml
+++ b/.github/workflows/reusable-verification.yml
@@ -105,6 +105,19 @@ jobs:
       - name: Checkout
         uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
 
+      - name: Free Disk Space (Ubuntu)
+        uses: jlumbroso/free-disk-space@v1.3.1
+        with:
+          # removes all pre-cached tools (Node, Go, Python, Ruby, ...)
+          tool-cache: true
+          # remove android runtime, dotnet runtime, haskell runtime, large packages, docker images, swap storage
+          android: true
+          dotnet: true
+          haskell: true
+          large-packages: true
+          docker-images: true
+          swap-storage: true
+
       - name: Set up Go
         uses: actions/setup-go@3041bf56c941b39c61721a86cd11f3bb1338122a # v5.2.0
         with:
@@ -112,24 +125,6 @@ jobs:
           # as it provides better flexibility like setting the cache key which reduces cache misses significantly.
           cache: false
           go-version-file: '.go-version'
-
-      - name: Free up disk space
-        run: |
-          df -h
-
-          # Remove .NET related tooling
-          sudo du -sh /usr/share/dotnet
-          sudo rm -rf /usr/share/dotnet
-
-          # Remove Android related tooling
-          sudo du -sh /usr/local/lib/android
-          sudo rm -rf /usr/local/lib/android
-
-          # Remove CodeQL
-          sudo du -sh /opt/hostedtoolcache/CodeQL
-          sudo rm -rf /opt/hostedtoolcache/CodeQL
-
-          df -h
 
       - name: Setup Go caching
         uses: actions/cache@1bd1e32a3bdc45362d1e726936510720a7c30a57 # v4.2.0


### PR DESCRIPTION
## Description

* Adopt https://github.com/jlumbroso/free-disk-space
* Fix [dependencies workflow](https://github.com/openclarity/openclarity/actions/workflows/dependencies.yml) failing with ´No space left on device´ 

## Type of Change

- [ ] Bug Fix
- [ ] New Feature
- [ ] Breaking Change
- [ ] Refactor
- [ ] Documentation
- [x] Other (please describe)

## Checklist

- [x] I have read the [contributing guidelines](https://github.com/openclarity/openclarity/blob/main/CONTRIBUTING.md)
- [ ] Existing issues have been referenced (where applicable)
- [x] I have verified this change is not present in other open pull requests
- [ ] Functionality is documented
- [x] All code style checks pass
- [ ] New code contribution is covered by automated tests
- [x] All new and existing tests pass
