### PR TITLE
ci(ci): setup go in dependencies workflow

### DIFF
--- a/.github/workflows/dependencies.yml
+++ b/.github/workflows/dependencies.yml
@@ -39,6 +39,14 @@ jobs:
       - name: Checkout
         uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
 
+      - name: Set up Go
+        uses: actions/setup-go@3041bf56c941b39c61721a86cd11f3bb1338122a # v5.2.0
+        with:
+          # NOTE(chrisgacsal): Use actions/cache for caching Go dependency and build caches
+          # as it provides better flexibility like setting the cache key which reduces cache misses significantly.
+          cache: false
+          go-version-file: '.go-version'
+
       - name: Run Renovate
         run: make renovate
         env:


### PR DESCRIPTION
## Description

Dependencies workflow needs `go` which is removed with the cleanup step (added with https://github.com/openclarity/openclarity/pull/964)

## Type of Change

- [x] Bug Fix
- [ ] New Feature
- [ ] Breaking Change
- [ ] Refactor
- [ ] Documentation
- [ ] Other (please describe)

## Checklist

- [x] I have read the [contributing guidelines](https://github.com/openclarity/openclarity/blob/main/CONTRIBUTING.md)
- [ ] Existing issues have been referenced (where applicable)
- [x] I have verified this change is not present in other open pull requests
- [ ] Functionality is documented
- [x] All code style checks pass
- [ ] New code contribution is covered by automated tests
- [x] All new and existing tests pass
