### PR TITLE
fix(charts): crDiscoveryServer environment variables not propagating

### DIFF
--- a/installation/kubernetes/helm/openclarity/templates/cr-discovery-server/daemonset.yaml
+++ b/installation/kubernetes/helm/openclarity/templates/cr-discovery-server/daemonset.yaml
@@ -34,7 +34,7 @@ spec:
           resources: {{- toYaml .Values.crDiscoveryServer.resources | nindent 12 }}
           {{- end }}
           {{- if .Values.crDiscoveryServer.env }}
-          resources: {{- toYaml .Values.crDiscoveryServer.env | nindent 12 }}
+          env: {{- toYaml .Values.crDiscoveryServer.env | nindent 12 }}
           {{- end }}
           volumeMounts:
             - mountPath: /var/run/containerd


### PR DESCRIPTION
## Description

<!-- Please provide a meaningful description of what this change will do, or is for. Bonus points for including links to
related issues, other PRs, or technical references and some before/after screenshots if the change affects the UI.

| Before | After |
| :---: | :---: |
| 🖼️ | 🖼️ |


Note that by _not_ including a description, you are asking reviewers to do extra work to understand the context of this
change, which may lead to your PR taking much longer to review, or result in it not being reviewed at all. -->

There is a typo in the templates preventing crDiscoveryServer env vars from propagating to the containers. 

## Type of Change

- [x] Bug Fix
- [ ] New Feature
- [ ] Breaking Change
- [ ] Refactor
- [ ] Documentation
- [ ] Other (please describe)

## Checklist

- [x] I have read the [contributing guidelines](https://github.com/openclarity/openclarity/blob/main/CONTRIBUTING.md)
- [x] Existing issues have been referenced (where applicable)
- [x] I have verified this change is not present in other open pull requests
- [x] Functionality is documented
- [x] All code style checks pass
- [x] New code contribution is covered by automated tests
- [x] All new and existing tests pass
