### PR TITLE
feat(charts): Correct Helm Chart templating in CR Discovery DaemonSet and Gateway Services

### DIFF
--- a/installation/kubernetes/helm/openclarity/templates/cr-discovery-server/daemonset.yaml
+++ b/installation/kubernetes/helm/openclarity/templates/cr-discovery-server/daemonset.yaml
@@ -21,7 +21,7 @@ spec:
       securityContext: {{- omit .Values.crDiscoveryServer.podSecurityContext "enabled" | toYaml | nindent 8 }}
       {{- end }}
       {{- if .Values.crDiscoveryServer.tolerations }}
-      tolerations: {{- .Values.crDiscoveryServer.tolerations | nindent 8 }}
+      tolerations: {{- .Values.crDiscoveryServer.tolerations | toYaml | nindent 8 }}
       {{- end }}
       containers:
         - name: cr-discovery-server

--- a/installation/kubernetes/helm/openclarity/templates/gateway/service-headless.yaml
+++ b/installation/kubernetes/helm/openclarity/templates/gateway/service-headless.yaml
@@ -5,7 +5,7 @@ metadata:
   namespace: {{ .Release.Namespace | quote }}
   labels: {{- include "openclarity.gateway.labels.standard" . | nindent 4 }}
   {{- if (not (empty .Values.gateway.service.annotations)) }}
-  annotations: {{ .Values.gateway.service.annotations }}
+  annotations: {{ .Values.gateway.service.annotations | toYaml | nindent 4 }}
   {{- end }}
 spec:
   type: ClusterIP

--- a/installation/kubernetes/helm/openclarity/templates/gateway/service.yaml
+++ b/installation/kubernetes/helm/openclarity/templates/gateway/service.yaml
@@ -5,7 +5,7 @@ metadata:
   namespace: {{ .Release.Namespace | quote }}
   labels: {{- include "openclarity.gateway.labels.standard" . | nindent 4 }}
   {{- if (not (empty .Values.gateway.service.annotations)) }}
-  annotations: {{ .Values.gateway.service.annotations }}
+  annotations: {{ .Values.gateway.service.annotations | toYaml | nindent 4 }}
   {{- end }}
 spec:
   type: {{ .Values.gateway.service.type }}


### PR DESCRIPTION
## Description

Fixes https://github.com/openclarity/openclarity/issues/1049

1. CR Discovery DaemonSet Toleration is now templated correctly
2. Gateway Annotations for both services `gateway` and `gateway-hl` are now templated correctly


## Type of Change

- [x] Bug Fix
- [ ] New Feature
- [ ] Breaking Change
- [ ] Refactor
- [ ] Documentation
- [ ] Other (please describe)

## Checklist

- [x] I have read the [contributing guidelines](https://github.com/openclarity/openclarity/blob/main/CONTRIBUTING.md)
- [x] Existing issues have been referenced (where applicable)
- [x] I have verified this change is not present in other open pull requests
- [x] Functionality is documented
- [x] All code style checks pass
- [x] New code contribution is covered by automated tests
- [x] All new and existing tests pass
